### PR TITLE
Fix V3021

### DIFF
--- a/src/Takenet.Elephant/AsyncEnumerableExtensions.cs
+++ b/src/Takenet.Elephant/AsyncEnumerableExtensions.cs
@@ -360,7 +360,7 @@ namespace Takenet.Elephant
         {
             if (source == null) throw new ArgumentNullException("source");
             if (keySelector == null) throw new ArgumentNullException("keySelector");
-            if (keySelector == null) throw new ArgumentNullException("elementSelector");
+            if (elementSelector == null) throw new ArgumentNullException("elementSelector");
 
             return ToDictionaryAsync(source, keySelector, elementSelector, null, CancellationToken.None);
         }
@@ -394,7 +394,7 @@ namespace Takenet.Elephant
         {
             if (source == null) throw new ArgumentNullException("source");
             if (keySelector == null) throw new ArgumentNullException("keySelector");
-            if (keySelector == null) throw new ArgumentNullException("elementSelector");
+            if (elementSelector == null) throw new ArgumentNullException("elementSelector");
 
             return ToDictionaryAsync(source, keySelector, elementSelector, null, cancellationToken);
         }
@@ -430,7 +430,7 @@ namespace Takenet.Elephant
         {
             if (source == null) throw new ArgumentNullException("source");
             if (keySelector == null) throw new ArgumentNullException("keySelector");
-            if (keySelector == null) throw new ArgumentNullException("elementSelector");
+            if (elementSelector == null) throw new ArgumentNullException("elementSelector");
 
             return ToDictionaryAsync(source, keySelector, elementSelector, comparer, CancellationToken.None);
         }
@@ -467,7 +467,7 @@ namespace Takenet.Elephant
         {
             if (source == null) throw new ArgumentNullException("source");
             if (keySelector == null) throw new ArgumentNullException("keySelector");
-            if (keySelector == null) throw new ArgumentNullException("elementSelector");
+            if (elementSelector == null) throw new ArgumentNullException("elementSelector");
 
             var d = new Dictionary<TKey, TElement>(comparer);
             await


### PR DESCRIPTION
Hello! I'm a member of the Pinguem.ru competition on finding errors in open source projects. A bug, found using PVS-Studio:

### V3021

- There are two 'if' statements with identical conditional expressions. The first 'if' statement contains method return. This means that the second 'if' statement is senseless Takenet.Elephant AsyncEnumerableExtensions.cs 362

- There are two 'if' statements with identical conditional expressions. The first 'if' statement contains method return. This means that the second 'if' statement is senseless Takenet.Elephant AsyncEnumerableExtensions.cs 396

- There are two 'if' statements with identical conditional expressions. The first 'if' statement contains method return. This means that the second 'if' statement is senseless Takenet.Elephant AsyncEnumerableExtensions.cs 432

- There are two 'if' statements with identical conditional expressions. The first 'if' statement contains method return. This means that the second 'if' statement is senseless Takenet.Elephant AsyncEnumerableExtensions.cs 469