### PR TITLE
Downgrade to NEST 6.8.2

### DIFF
--- a/src/Take.Elephant.ElasticSearch/ElasticsearchSet.cs
+++ b/src/Take.Elephant.ElasticSearch/ElasticsearchSet.cs
@@ -41,6 +41,7 @@ namespace Take.Elephant.Elasticsearch
         {
             var results = await ElasticClient.SearchAsync<T>(c => c
             .Index(Mapping.Index)
+            .Type(Mapping.Type)
             .Query(q => q.MatchAll()));
 
             return new AsyncEnumerableWrapper<T>(results.Documents);
@@ -61,6 +62,7 @@ namespace Take.Elephant.Elasticsearch
         {
             var result = await ElasticClient.CountAsync<T>(c => c
                 .Index(Mapping.Index)
+                .Type(Mapping.Type)
                 .Query(q => q.MatchAll()));
 
             return result.Count;

--- a/src/Take.Elephant.ElasticSearch/Mapping/IMapping.cs
+++ b/src/Take.Elephant.ElasticSearch/Mapping/IMapping.cs
@@ -15,6 +15,11 @@ namespace Take.Elephant.Elasticsearch.Mapping
         string Index { get; }
 
         /// <summary>
+        /// Elasticsearch document type
+        /// </summary>
+        string Type { get; }
+
+        /// <summary>
         /// Elasticsearch document key field
         /// </summary>
         string KeyField { get; }

--- a/src/Take.Elephant.ElasticSearch/Mapping/Mapping.cs
+++ b/src/Take.Elephant.ElasticSearch/Mapping/Mapping.cs
@@ -11,9 +11,10 @@ namespace Take.Elephant.Elasticsearch.Mapping
         /// </summary>
         /// <param name="index"></param>
         /// <param name="keyField"></param>
-        public Mapping(string index, string keyField)
+        public Mapping(string index, string type, string keyField)
         {
             Index = index;
+            Type = type ?? "_doc";
             KeyField = keyField;
         }
 
@@ -21,6 +22,11 @@ namespace Take.Elephant.Elasticsearch.Mapping
         /// Gets the document Index
         /// </summary>
         public string Index { get; set; }
+
+        /// <summary>
+        /// Gets the type of document
+        /// </summary>
+        public string Type { get; set; }
 
         /// <summary>
         /// Gets the key field

--- a/src/Take.Elephant.ElasticSearch/Mapping/MappingBuilder.cs
+++ b/src/Take.Elephant.ElasticSearch/Mapping/MappingBuilder.cs
@@ -33,6 +33,11 @@ namespace Take.Elephant.Elasticsearch.Mapping
         public string KeyField { get; set; }
 
         /// <summary>
+        /// Gets the key field
+        /// </summary>
+        public string Type { get; set; }
+
+        /// <summary>
         /// Includes the document index name
         /// </summary>
         /// <param name="index"></param>
@@ -43,12 +48,23 @@ namespace Take.Elephant.Elasticsearch.Mapping
         }
 
         /// <summary>
+        /// Includes the document type name
+        /// </summary>
+        /// <param name="index"></param>
+        /// <returns></returns>
+        public MappingBuilder WithType(string type)
+        {
+            Type = type;
+            return this;
+        }
+
+        /// <summary>
         /// Creates an IMapping instance based on the provided parameters
         /// </summary>
         /// <returns></returns>
         public IMapping Build()
         {
-            return new Mapping(Index, KeyField);
+            return new Mapping(Index, Type, KeyField);
         }
     }
 }

--- a/src/Take.Elephant.ElasticSearch/StorageBase.cs
+++ b/src/Take.Elephant.ElasticSearch/StorageBase.cs
@@ -53,6 +53,7 @@ namespace Take.Elephant.Elasticsearch
 
             var result = await ElasticClient.SearchAsync<T>(s => s
                 .Index(Mapping.Index)
+                .Type(Mapping.Type)
                 .Query(_ => queryDescriptor)
                 .From(skip).Size(take), cancellationToken);
 
@@ -67,7 +68,9 @@ namespace Take.Elephant.Elasticsearch
             }
 
             var response = await ElasticClient.DocumentExistsAsync<T>(key, d => d
-                .Index(Mapping.Index), cancellationToken);
+                .Index(Mapping.Index)
+                .Type(Mapping.Type),
+                cancellationToken);
 
             return response.Exists;
         }
@@ -80,7 +83,9 @@ namespace Take.Elephant.Elasticsearch
             }
 
             var result = await ElasticClient.GetAsync<T>(key,
-                d => d.Index(Mapping.Index),
+                d => d
+                .Index(Mapping.Index)
+                .Type(Mapping.Type),
                 cancellationToken);
 
             return result?.Source;
@@ -100,7 +105,9 @@ namespace Take.Elephant.Elasticsearch
 
             if (overwrite || !await ContainsKeyAsync(key, cancellationToken))
             {
-                var result = await ElasticClient.IndexAsync(new IndexRequest<T>(value, Mapping.Index,
+                var result = await ElasticClient.IndexAsync(new IndexRequest<T>(value,
+                    Mapping.Index,
+                    Mapping.Type,
                     key.ToString()), cancellationToken);
 
                 return result.IsValid;
@@ -117,7 +124,9 @@ namespace Take.Elephant.Elasticsearch
             }
 
             var result = await ElasticClient.DeleteAsync<T>(key,
-                d => d.Index(Mapping.Index), cancellationToken);
+                d => d.Index(Mapping.Index)
+                      .Type(Mapping.Type),
+                cancellationToken);
 
             return result.IsValid;
         }

--- a/src/Take.Elephant.ElasticSearch/Take.Elephant.ElasticSearch.csproj
+++ b/src/Take.Elephant.ElasticSearch/Take.Elephant.ElasticSearch.csproj
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NEST" Version="7.1.0" />
+    <PackageReference Include="NEST" Version="6.8.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Downgraded NEST version and included es type mapping
This modification is required because there are some breaking changes in NEST 7.x vs Elasticsearch 6.x
