### PR TITLE
Create the option to Remove Expiration Date from register

### DIFF
--- a/src/Take.Elephant.Redis/MapBase.cs
+++ b/src/Take.Elephant.Redis/MapBase.cs
@@ -49,6 +49,13 @@ namespace Take.Elephant.Redis
             return database.KeyExpireAsync(GetRedisKey(key), expiration.UtcDateTime, WriteFlags);
         }
 
+        public virtual Task<bool> RemoveExpirationAsync(TKey key)
+        {
+            if (key == null) throw new ArgumentException(nameof(key));
+            var database = GetDatabase();
+            return database.KeyPersistAsync(GetRedisKey(key), WriteFlags);
+        }
+
         #endregion
 
         public virtual Task<IAsyncEnumerable<TKey>> GetKeysAsync()

--- a/src/Take.Elephant.Specialized/Cache/OnDemandCacheMap.cs
+++ b/src/Take.Elephant.Specialized/Cache/OnDemandCacheMap.cs
@@ -142,7 +142,34 @@ namespace Take.Elephant.Specialized.Cache
 
             return success;
         }
-        
+
+        public virtual async Task<bool> RemoveExpirationAsync(TKey key)
+        {
+            if (!(Source is IExpirableKeyMap<TKey, TValue> expirableSource))
+            {
+                throw new NotSupportedException("The source map doesn't implement IExpirableKeyMap");
+            }
+
+            if (!(Cache is IExpirableKeyMap<TKey, TValue> expirableCache))
+            {
+                throw new NotSupportedException("The cache map doesn't implement IExpirableKeyMap");
+            }
+
+            var success = await expirableSource.RemoveExpirationAsync(key);
+            if (success)
+            {
+                success = await expirableCache.RemoveExpirationAsync(key);
+            }
+
+            return success;
+        }
+
+        private void VerifySourceCacheExpirableType()
+        {
+
+        }
+
+
         protected async Task<bool> TryAddWithExpirationAsync(TKey key, TValue value, bool overwrite, IMap<TKey, TValue> map, CancellationToken cancellationToken)
         {
             var added = await map.TryAddAsync(key, value, overwrite, cancellationToken).ConfigureAwait(false);

--- a/src/Take.Elephant.Specialized/Cache/OnDemandCacheMap.cs
+++ b/src/Take.Elephant.Specialized/Cache/OnDemandCacheMap.cs
@@ -24,22 +24,22 @@ namespace Take.Elephant.Specialized.Cache
 
             CacheExpiration = cacheExpiration;
             CacheFaultTolerance = cacheFaultTolerance;
-            _implementsPropertyMap = Source is IPropertyMap<TKey, TValue> && 
+            _implementsPropertyMap = Source is IPropertyMap<TKey, TValue> &&
                                      Cache is IPropertyMap<TKey, TValue>;
         }
 
         public virtual Task<bool> TryAddAsync(TKey key,
             TValue value,
             bool overwrite = false,
-            CancellationToken cancellationToken = default) => 
+            CancellationToken cancellationToken = default) =>
             ExecuteWriteFunc(map => TryAddWithExpirationAsync(key, value, overwrite, map, cancellationToken));
 
-        public virtual Task<TValue> GetValueOrDefaultAsync(TKey key, CancellationToken cancellationToken = default) => 
+        public virtual Task<TValue> GetValueOrDefaultAsync(TKey key, CancellationToken cancellationToken = default) =>
             ExecuteQueryFunc(
                 map => map.GetValueOrDefaultAsync(key, cancellationToken),
                 (result, m) => TryAddWithExpirationAsync(key, result, true, m, cancellationToken));
 
-        public virtual Task<bool> TryRemoveAsync(TKey key, CancellationToken cancellationToken = default) => 
+        public virtual Task<bool> TryRemoveAsync(TKey key, CancellationToken cancellationToken = default) =>
             ExecuteWriteFunc(map => map.TryRemoveAsync(key, cancellationToken));
 
         public virtual Task<bool> ContainsKeyAsync(TKey key, CancellationToken cancellationToken = default)
@@ -69,7 +69,7 @@ namespace Take.Elephant.Specialized.Cache
                 return Task.FromException(
                     new NotSupportedException("Either the source or cache map doesn't implement IPropertyMap"));
             }
-            
+
             return ExecuteWriteFunc(map => ((IPropertyMap<TKey, TValue>)map).SetPropertyValueAsync(key, propertyName, propertyValue, cancellationToken));
         }
 
@@ -81,7 +81,7 @@ namespace Take.Elephant.Specialized.Cache
                 return Task.FromException<TProperty>(
                     new NotSupportedException("Either the source or cache map doesn't implement IPropertyMap"));
             }
-            
+
             return ExecuteQueryFunc(map =>
                     ((IPropertyMap<TKey, TValue>)map).GetPropertyValueOrDefaultAsync<TProperty>(key, propertyName, cancellationToken),
                 (propertyValue, map) =>
@@ -95,27 +95,19 @@ namespace Take.Elephant.Specialized.Cache
                 return Task.FromException(
                     new NotSupportedException("Either the source or cache map doesn't implement IPropertyMap"));
             }
-            
+
             return ExecuteWriteFunc(map => ((IPropertyMap<TKey, TValue>)map).MergeAsync(key, value, cancellationToken));
         }
 
         public virtual async Task<bool> SetRelativeKeyExpirationAsync(TKey key, TimeSpan ttl)
         {
-            if (!(Source is IExpirableKeyMap<TKey, TValue> expirableSource))
-            {
-                throw new NotSupportedException("The source map doesn't implement IExpirableKeyMap");
-            }
+            var expirableOnDemand = VerifySourceCacheExpirableType();
 
-            if (!(Cache is IExpirableKeyMap<TKey, TValue> expirableCache))
-            {
-                throw new NotSupportedException("The cache map doesn't implement IExpirableKeyMap");
-            }
-
-            var success = await expirableSource.SetRelativeKeyExpirationAsync(key, ttl);
+            var success = await expirableOnDemand.expirableSource.SetRelativeKeyExpirationAsync(key, ttl);
             if (success &&
                 ttl < CacheExpiration)
             {
-                success = await expirableCache.SetRelativeKeyExpirationAsync(key, ttl.Add(CacheFaultTolerance));
+                success = await expirableOnDemand.expirableCache.SetRelativeKeyExpirationAsync(key, ttl.Add(CacheFaultTolerance));
             }
 
             return success;
@@ -123,21 +115,13 @@ namespace Take.Elephant.Specialized.Cache
 
         public virtual async Task<bool> SetAbsoluteKeyExpirationAsync(TKey key, DateTimeOffset expiration)
         {
-            if (!(Source is IExpirableKeyMap<TKey, TValue> expirableSource))
-            {
-                throw new NotSupportedException("The source map doesn't implement IExpirableKeyMap");
-            }
+            var expirableOnDemand = VerifySourceCacheExpirableType();
 
-            if (!(Cache is IExpirableKeyMap<TKey, TValue> expirableCache))
-            {
-                throw new NotSupportedException("The cache map doesn't implement IExpirableKeyMap");
-            }
-
-            var success = await expirableSource.SetAbsoluteKeyExpirationAsync(key, expiration);
+            var success = await expirableOnDemand.expirableSource.SetAbsoluteKeyExpirationAsync(key, expiration);
             if (success &&
                 expiration - DateTimeOffset.UtcNow < CacheExpiration)
             {
-                success = await expirableCache.SetAbsoluteKeyExpirationAsync(key, expiration.Add(CacheFaultTolerance));
+                success = await expirableOnDemand.expirableCache.SetAbsoluteKeyExpirationAsync(key, expiration.Add(CacheFaultTolerance));
             }
 
             return success;
@@ -145,6 +129,19 @@ namespace Take.Elephant.Specialized.Cache
 
         public virtual async Task<bool> RemoveExpirationAsync(TKey key)
         {
+            var expirableOnDemand = VerifySourceCacheExpirableType();
+
+            var success = await expirableOnDemand.expirableSource.RemoveExpirationAsync(key);
+            if (success)
+            {
+                success = await expirableOnDemand.expirableCache.RemoveExpirationAsync(key);
+            }
+
+            return success;
+        }
+
+        private (IExpirableKeyMap<TKey, TValue> expirableSource, IExpirableKeyMap<TKey, TValue> expirableCache) VerifySourceCacheExpirableType()
+        {
             if (!(Source is IExpirableKeyMap<TKey, TValue> expirableSource))
             {
                 throw new NotSupportedException("The source map doesn't implement IExpirableKeyMap");
@@ -155,27 +152,16 @@ namespace Take.Elephant.Specialized.Cache
                 throw new NotSupportedException("The cache map doesn't implement IExpirableKeyMap");
             }
 
-            var success = await expirableSource.RemoveExpirationAsync(key);
-            if (success)
-            {
-                success = await expirableCache.RemoveExpirationAsync(key);
-            }
-
-            return success;
-        }
-
-        private void VerifySourceCacheExpirableType()
-        {
-
+            return (expirableSource, expirableCache);
         }
 
 
         protected async Task<bool> TryAddWithExpirationAsync(TKey key, TValue value, bool overwrite, IMap<TKey, TValue> map, CancellationToken cancellationToken)
         {
             var added = await map.TryAddAsync(key, value, overwrite, cancellationToken).ConfigureAwait(false);
-            if (added && 
-                map == Cache && 
-                CacheExpiration != default && 
+            if (added &&
+                map == Cache &&
+                CacheExpiration != default &&
                 map is IExpirableKeyMap<TKey, TValue> expirableMap)
             {
                 await expirableMap.SetRelativeKeyExpirationAsync(key, CacheExpiration).ConfigureAwait(false);

--- a/src/Take.Elephant.Sql/ExpirableKeySqlMap.cs
+++ b/src/Take.Elephant.Sql/ExpirableKeySqlMap.cs
@@ -85,13 +85,13 @@ namespace Take.Elephant.Sql
                     schemaName = DatabaseDriver.ParseIdentifier(Table.Schema ?? DatabaseDriver.DefaultSchema),
                     tableName = DatabaseDriver.ParseIdentifier(Table.Name),
                     columnValues = SqlHelper.GetCommaEqualsStatement(DatabaseDriver, columnValues.Keys.ToArray()),
-                    filter = SqlHelper.CombineAndEqualsWithIsNotNullStatement(DatabaseDriver, 
+                    filter = SqlHelper.GetCombinedAndStatement(DatabaseDriver, 
                                                                                              SqlHelper.GetAndEqualsStatement(DatabaseDriver, keyColumnValues.Keys.ToArray()),
                                                                                              SqlHelper.GetIsNotNullStatement(DatabaseDriver, columnValues.Keys.ToArray()))
                 },
                 keyColumnValues.Concat(columnValues).Select(c => c.ToDbParameter(DatabaseDriver)));
 
-            var teste = SqlHelper.CombineAndEqualsWithIsNotNullStatement(DatabaseDriver,
+            var teste = SqlHelper.GetCombinedAndStatement(DatabaseDriver,
                                                                                              SqlHelper.GetAndEqualsStatement(DatabaseDriver, keyColumnValues.Keys.ToArray()),
                                                                                              SqlHelper.GetIsNotNullStatement(DatabaseDriver, columnValues.Keys.ToArray()));
 

--- a/src/Take.Elephant.Sql/SqlHelper.cs
+++ b/src/Take.Elephant.Sql/SqlHelper.cs
@@ -85,11 +85,11 @@ namespace Take.Elephant.Sql
                 databaseDriver.GetSqlStatementTemplate(SqlStatement.And),
                 columns,
                 columns,
-                (d, c, p) => databaseDriver.GetSqlStatementTemplate(SqlStatement.QueryEquals).Format(
+                (_, column, __) => databaseDriver.GetSqlStatementTemplate(SqlStatement.QueryEquals).Format(
                     new
                     {
-                        column = $"{databaseDriver.ParseIdentifier(sourceTableName)}.{databaseDriver.ParseIdentifier(c)}",
-                        value = $"{databaseDriver.ParseIdentifier(targetTableName)}.{databaseDriver.ParseIdentifier(c)}",
+                        column = $"{databaseDriver.ParseIdentifier(sourceTableName)}.{databaseDriver.ParseIdentifier(column)}",
+                        value = $"{databaseDriver.ParseIdentifier(targetTableName)}.{databaseDriver.ParseIdentifier(column)}",
                     }));
 
         }
@@ -99,14 +99,15 @@ namespace Take.Elephant.Sql
             return GetSeparateColumnsStatement(databaseDriver,
                   databaseDriver.GetSqlStatementTemplate(SqlStatement.And),
                   columns,
-                  columns, (d, c, p) => databaseDriver.GetSqlStatementTemplate(SqlStatement.QueryIsNotNull).Format(
-                               new
-                               {
-                                   column = databaseDriver.ParseIdentifier(c)
-                               }));
+                  columns,
+                  (_, column, __) => databaseDriver.GetSqlStatementTemplate(SqlStatement.QueryIsNotNull).Format(
+                      new
+                      {
+                          column = databaseDriver.ParseIdentifier(column)
+                      }));
         }
 
-        public static string CombineAndEqualsWithIsNotNullStatement(IDatabaseDriver databaseDriver, string andEqualStatement, string isNotNullStatement) => $"{andEqualStatement} {databaseDriver.GetSqlStatementTemplate(SqlStatement.And)} {isNotNullStatement}";
+        public static string GetCombinedAndStatement(IDatabaseDriver databaseDriver, string firstStatement, string secondStatement) => $"({firstStatement}) {databaseDriver.GetSqlStatementTemplate(SqlStatement.And)} ({secondStatement})";
 
         public static string GetSeparateColumnsStatement(IDatabaseDriver databaseDriver, string separator, string[] columns, string[] parameters, Func<IDatabaseDriver, string, string, string> statement)
         {

--- a/src/Take.Elephant.Sql/SqlHelper.cs
+++ b/src/Take.Elephant.Sql/SqlHelper.cs
@@ -3,12 +3,13 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Linq.Expressions;
+using System.Net.NetworkInformation;
 using System.Text;
 
 namespace Take.Elephant.Sql
 {
     public static class SqlHelper
-    {        
+    {
         public static string GetAndEqualsStatement(IDatabaseDriver databaseDriver, IDictionary<string, object> filterValues)
         {
             if (filterValues == null) return databaseDriver.GetSqlStatementTemplate(SqlStatement.OneEqualsOne);
@@ -23,7 +24,7 @@ namespace Take.Elephant.Sql
         public static string GetAndEqualsStatement(IDatabaseDriver databaseDriver, string[] columns, string[] parameters)
         {
             return columns.Length == 0 ?
-                databaseDriver.GetSqlStatementTemplate(SqlStatement.OneEqualsOne) : 
+                databaseDriver.GetSqlStatementTemplate(SqlStatement.OneEqualsOne) :
                 GetSeparateEqualsStatement(databaseDriver, databaseDriver.GetSqlStatementTemplate(SqlStatement.And), columns, parameters);
         }
 
@@ -93,6 +94,20 @@ namespace Take.Elephant.Sql
 
         }
 
+        public static string GetIsNotNullStatement(IDatabaseDriver databaseDriver, string[] columns)
+        {
+            return GetSeparateColumnsStatement(databaseDriver,
+                  databaseDriver.GetSqlStatementTemplate(SqlStatement.And),
+                  columns,
+                  columns, (d, c, p) => databaseDriver.GetSqlStatementTemplate(SqlStatement.QueryIsNotNull).Format(
+                               new
+                               {
+                                   column = databaseDriver.ParseIdentifier(c)
+                               }));
+        }
+
+        public static string CombineAndEqualsWithIsNotNullStatement(IDatabaseDriver databaseDriver, string andEqualStatement, string isNotNullStatement) => $"{andEqualStatement} {databaseDriver.GetSqlStatementTemplate(SqlStatement.And)} {isNotNullStatement}";
+
         public static string GetSeparateColumnsStatement(IDatabaseDriver databaseDriver, string separator, string[] columns, string[] parameters, Func<IDatabaseDriver, string, string, string> statement)
         {
             if (columns.Length == 0)
@@ -125,8 +140,8 @@ namespace Take.Elephant.Sql
         }
 
         public static SqlWhereStatement TranslateToSqlWhereClause<TEntity>(
-            IDatabaseDriver databaseDriver, 
-            Expression<Func<TEntity, bool>> where, 
+            IDatabaseDriver databaseDriver,
+            Expression<Func<TEntity, bool>> where,
             IDbTypeMapper dbTypeMapper,
             IDictionary<string, string> parameterReplacementDictionary = null)
         {
@@ -134,7 +149,7 @@ namespace Take.Elephant.Sql
             {
                 return new SqlWhereStatement(databaseDriver.GetSqlStatementTemplate(SqlStatement.OneEqualsOne), new Dictionary<string, object>());
             }
-            
+
             var translator = new SqlExpressionTranslator(databaseDriver, dbTypeMapper, parameterReplacementDictionary);
             return translator.GetStatement(where);
         }

--- a/src/Take.Elephant.Sql/SqlStatement.cs
+++ b/src/Take.Elephant.Sql/SqlStatement.cs
@@ -30,6 +30,7 @@ namespace Take.Elephant.Sql
         PrimaryKeyConstraintDefinition,
         QueryEquals,
         QueryGreatherThen,
+        QueryIsNotNull,
         QueryLessThen,
         Select,
         SelectCount,

--- a/src/Take.Elephant.Sql/SqlTemplates.Designer.cs
+++ b/src/Take.Elephant.Sql/SqlTemplates.Designer.cs
@@ -19,7 +19,7 @@ namespace Take.Elephant.Sql {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "16.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class SqlTemplates {
@@ -355,10 +355,17 @@ namespace Take.Elephant.Sql {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to set transaction isolation level serializable;
-        ///INSERT INTO {schemaName}.{tableName} ({columns}) 
-        ///SELECT {values}
-        ///WHERE NOT EXISTS ( SELECT 1 FROM {schemaName}.{tableName} WHERE {filter} ).
+        ///   Looks up a localized string similar to 
+        ///      BEGIN TRY
+        ///        INSERT INTO {schemaName}.{tableName} ({columns}) 
+        ///        SELECT {values}
+        ///        WHERE NOT EXISTS ( SELECT 1 FROM {schemaName}.{tableName} WHERE {filter} )
+        ///      END TRY
+        ///      BEGIN CATCH
+        ///        IF ERROR_NUMBER() &lt;&gt; 2627
+        ///        THROW
+        ///      END CATCH
+        ///    .
         /// </summary>
         public static string InsertWhereNotExists {
             get {
@@ -575,6 +582,15 @@ namespace Take.Elephant.Sql {
         public static string QueryGreatherThen {
             get {
                 return ResourceManager.GetString("QueryGreatherThen", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to {column} IS NOT NULL.
+        /// </summary>
+        public static string QueryIsNotNull {
+            get {
+                return ResourceManager.GetString("QueryIsNotNull", resourceCulture);
             }
         }
         

--- a/src/Take.Elephant.Sql/SqlTemplates.resx
+++ b/src/Take.Elephant.Sql/SqlTemplates.resx
@@ -312,6 +312,9 @@ OUTPUT inserted.{incrementColumnName};</value>
   <data name="QueryGreatherThen" xml:space="preserve">
     <value>{column} &gt; {value}</value>
   </data>
+  <data name="QueryIsNotNull" xml:space="preserve">
+    <value>{column} IS NOT NULL</value>
+  </data>
   <data name="QueryLessThen" xml:space="preserve">
     <value>{column} &lt; {value}</value>
   </data>

--- a/src/Take.Elephant.Tests/ExpirableKeyMapFacts.cs
+++ b/src/Take.Elephant.Tests/ExpirableKeyMapFacts.cs
@@ -163,22 +163,5 @@ namespace Take.Elephant.Tests
             //Assert
             removedExpired.ShouldBeTrue();
         }
-
-        [Fact(DisplayName =nameof(RemoveExpirationFromExistentPersistantKeyReturnFalse))]
-        public async Task RemoveExpirationFromExistentPersistantKeyReturnFalse()
-        {
-            // Arrange
-            var map = Create();
-            var key = CreateKey();
-            var value = CreateValue(key);
-            if (!await map.TryAddAsync(key, value, false)) throw new Exception("Could not arrange the test");
-
-            // Act
-            var removedExpired = await map.RemoveExpirationAsync(key);
-
-            // Assert
-            removedExpired.ShouldBeFalse();
-        }
-
     }
 }

--- a/src/Take.Elephant.Tests/ExpirableKeyMapFacts.cs
+++ b/src/Take.Elephant.Tests/ExpirableKeyMapFacts.cs
@@ -27,7 +27,7 @@ namespace Take.Elephant.Tests
 
         [Fact(DisplayName = "ExpireExistingKeyByRelativeTtlSucceeds")]
         public async Task ExpireExistingKeyByRelativeTtlSucceeds()
-        {            
+        {
             // Arrange
             var map = Create();
             var key = CreateKey();
@@ -77,7 +77,7 @@ namespace Take.Elephant.Tests
 
             // Act
             await map.SetRelativeKeyExpirationAsync(key, ttl + ttl + ttl);
-            
+
             // Assert
             await Task.Delay(ttl);
             var actual = await map.GetValueOrDefaultAsync(key);
@@ -100,7 +100,7 @@ namespace Take.Elephant.Tests
             var expiration = now.Add(ttl);
             var updatedExpiration = now.Add(ttl + ttl + ttl);
             await map.SetAbsoluteKeyExpirationAsync(key, expiration);
-            
+
             // Act
             await map.SetAbsoluteKeyExpirationAsync(key, updatedExpiration);
 
@@ -123,7 +123,7 @@ namespace Take.Elephant.Tests
 
             // Act
             var actual = await map.SetRelativeKeyExpirationAsync(key, ttl);
-            
+
             // Assert
             actual.ShouldBeFalse();
         }
@@ -139,9 +139,46 @@ namespace Take.Elephant.Tests
 
             // Act
             var actual = await map.SetAbsoluteKeyExpirationAsync(key, expiration);
-            
+
             // Assert
             actual.ShouldBeFalse();
         }
+
+        [Fact(DisplayName = nameof(RemoveExpirationFromExistentVolatileKeyReturnsTrue))]
+        public async Task RemoveExpirationFromExistentVolatileKeyReturnsTrue()
+        {
+            // Arrange
+            var map = Create();
+            var key = CreateKey();
+            var value = CreateValue(key);
+            if (!await map.TryAddAsync(key, value, false)) throw new Exception("Could not arrange the test");
+            var ttl = CreateTtl();
+            var now = DateTimeOffset.UtcNow;
+            var expiration = now.Add(ttl);
+            await map.SetAbsoluteKeyExpirationAsync(key, expiration);
+
+            //Act
+            var removedExpired = await map.RemoveExpirationAsync(key);
+
+            //Assert
+            removedExpired.ShouldBeTrue();
+        }
+
+        [Fact(DisplayName =nameof(RemoveExpirationFromExistentPersistantKeyReturnFalse))]
+        public async Task RemoveExpirationFromExistentPersistantKeyReturnFalse()
+        {
+            // Arrange
+            var map = Create();
+            var key = CreateKey();
+            var value = CreateValue(key);
+            if (!await map.TryAddAsync(key, value, false)) throw new Exception("Could not arrange the test");
+
+            // Act
+            var removedExpired = await map.RemoveExpirationAsync(key);
+
+            // Assert
+            removedExpired.ShouldBeFalse();
+        }
+
     }
 }

--- a/src/Take.Elephant.Tests/ExpirableKeyMapFacts.cs
+++ b/src/Take.Elephant.Tests/ExpirableKeyMapFacts.cs
@@ -163,5 +163,21 @@ namespace Take.Elephant.Tests
             //Assert
             removedExpired.ShouldBeTrue();
         }
+
+        [Fact(DisplayName = nameof(RemoveExpirationFromExistentPersistentKeyReturnsFalse))]
+        public async Task RemoveExpirationFromExistentPersistentKeyReturnsFalse()
+        {
+            // Arrange
+            var map = Create();
+            var key = CreateKey();
+            var value = CreateValue(key);
+            if (!await map.TryAddAsync(key, value, false)) throw new Exception("Could not arrange the test");
+
+            //Act
+            var removedExpired = await map.RemoveExpirationAsync(key);
+
+            //Assert
+            removedExpired.ShouldBeFalse();
+        }
     }
 }

--- a/src/Take.Elephant/IExpirableKeyMap.cs
+++ b/src/Take.Elephant/IExpirableKeyMap.cs
@@ -25,5 +25,12 @@ namespace Take.Elephant
         /// <param name="expiration">The expiration.</param>
         /// <returns></returns>
         Task<bool> SetAbsoluteKeyExpirationAsync(TKey key, DateTimeOffset expiration);
+
+        /// <summary>
+        /// Remove expiration value from a register
+        /// </summary>
+        /// <param name="key">The key.</param>
+        /// <returns></returns>
+        Task<bool> RemoveExpirationAsync(TKey key);
     }
 }

--- a/src/Take.Elephant/Memory/Map.cs
+++ b/src/Take.Elephant/Memory/Map.cs
@@ -52,7 +52,7 @@ namespace Take.Elephant.Memory
             {
                 expirationScanInterval = TimeSpan.FromSeconds(30);
             }
-            _expirationTimerIntervalMs = expirationScanInterval.TotalMilliseconds; 
+            _expirationTimerIntervalMs = expirationScanInterval.TotalMilliseconds;
             _expirationTimer = new Timer(_expirationTimerIntervalMs);
             _expirationTimer.Elapsed += RemoveExpiredKeys;
         }
@@ -68,7 +68,7 @@ namespace Take.Elephant.Memory
         protected IDictionaryConverter<TValue> DictionaryConverter { get; }
 
         protected ConcurrentDictionary<TKey, TValue> InternalDictionary { get; }
-        
+
         protected ConcurrentDictionary<TKey, DateTimeOffset> KeyExpirationDictionary { get; }
 
         public virtual Task<bool> TryAddAsync(
@@ -79,7 +79,7 @@ namespace Take.Elephant.Memory
         {
             if (key == null) throw new ArgumentNullException(nameof(key));
             bool added;
-            
+
             if (overwrite)
             {
                 InternalDictionary.AddOrUpdate(key, value, (k, v) => value);
@@ -171,9 +171,8 @@ namespace Take.Elephant.Memory
                 return Task.FromResult(false);
             }
 
-            KeyExpirationDictionary.TryRemove(key, out _);
-
-            return Task.FromResult(true);
+            var removed = KeyExpirationDictionary.TryRemove(key, out _);
+            return Task.FromResult(removed);
         }
 
         public virtual Task SetPropertyValueAsync<TProperty>(TKey key, string propertyName, TProperty propertyValue, CancellationToken cancellationToken = default)
@@ -202,8 +201,8 @@ namespace Take.Elephant.Memory
             if (property == null) throw new ArgumentException("The property name is invalid", nameof(propertyName));
             var propertyValue = default(TProperty);
             if (InternalDictionary.TryGetValue(key, out value))
-            { 
-                propertyValue = (TProperty) property.GetValue(value);
+            {
+                propertyValue = (TProperty)property.GetValue(value);
             }
             return Task.FromResult(propertyValue);
         }
@@ -280,7 +279,7 @@ namespace Take.Elephant.Memory
             }
             var totalValues = InternalDictionary
                 .Where(pair => KeyHasNotExpired(pair.Key) && where.Compile().Invoke(pair.Value));
-            
+
             var totalCount = 0;
             if (FetchQueryResultTotal)
             {
@@ -304,7 +303,7 @@ namespace Take.Elephant.Memory
             CancellationToken cancellationToken)
         {
             if (@where == null) @where = value => true;
-            if (select != null && 
+            if (select != null &&
                 select.ReturnType != typeof(TValue))
             {
                 throw new NotImplementedException("The select parameter is not supported yet");
@@ -318,7 +317,7 @@ namespace Take.Elephant.Memory
             {
                 totalCount = totalValues.Count();
             }
-            
+
             var resultValues = totalValues
                 .Skip(skip)
                 .Take(take)
@@ -349,15 +348,15 @@ namespace Take.Elephant.Memory
                 .Select(pair => pair.Value)
                 .Where(value => where.Compile().Invoke(value));
             var orderByFunc = orderBy.Compile();
-            
+
             int totalCount = 0;
             if (FetchQueryResultTotal)
             {
                 totalCount = totalValues.Count();
             }
 
-            var orderedTotalValues = orderByAscending 
-                ? totalValues.OrderBy(orderByFunc.Invoke) 
+            var orderedTotalValues = orderByAscending
+                ? totalValues.OrderBy(orderByFunc.Invoke)
                 : totalValues.OrderByDescending(orderByFunc.Invoke);
 
             var resultValues = orderedTotalValues
@@ -390,7 +389,7 @@ namespace Take.Elephant.Memory
             {
                 totalCount = totalValues.Count();
             }
-            
+
             var resultValues = totalValues
                 .Skip(skip)
                 .Take(take);
@@ -405,7 +404,7 @@ namespace Take.Elephant.Memory
             {
                 return value;
             }
-            
+
             value = ValueFactory();
             InternalDictionary[key] = value;
             KeyExpirationDictionary.TryRemove(key, out _);
@@ -427,10 +426,10 @@ namespace Take.Elephant.Memory
 
 
         protected bool KeyHasNotExpired(TKey key) => !KeyHasExpired(key);
-        
+
         protected bool KeyHasExpired(TKey key)
         {
-            return KeyExpirationDictionary.TryGetValue(key, out var expiration) && 
+            return KeyExpirationDictionary.TryGetValue(key, out var expiration) &&
                    expiration <= DateTimeOffset.UtcNow;
         }
 

--- a/src/Take.Elephant/Memory/Map.cs
+++ b/src/Take.Elephant/Memory/Map.cs
@@ -163,6 +163,19 @@ namespace Take.Elephant.Memory
             return Task.FromResult(true);
         }
 
+        public virtual Task<bool> RemoveExpirationAsync(TKey key)
+        {
+            if (key == null) throw new ArgumentNullException(nameof(key));
+            if (!InternalDictionary.ContainsKey(key))
+            {
+                return Task.FromResult(false);
+            }
+
+            KeyExpirationDictionary.TryRemove(key, out _);
+
+            return Task.FromResult(true);
+        }
+
         public virtual Task SetPropertyValueAsync<TProperty>(TKey key, string propertyName, TProperty propertyValue, CancellationToken cancellationToken = default)
         {
             if (key == null) throw new ArgumentNullException(nameof(key));


### PR DESCRIPTION
In this request, I'm adding the possibility to turn a volatile register in a Persistent register, removing the expiration date information from the row.

To make this, i created a method called **RemoveExpirationAsync** and:

- In Redis, I'm using the Persist concept, to turn a volatile entry in an persistent information
- In SQL, I'm removing the date information from respective column
- In Memory, I'm remove the key information from expirable dictionary entry, so the event that expires the key will ignore the register.