### PR TITLE
Add validation for sql queries with multiple params of same column, to try get the type for all params

### DIFF
--- a/src/Take.Elephant.Sql/SqlExpressionTranslator.cs
+++ b/src/Take.Elephant.Sql/SqlExpressionTranslator.cs
@@ -11,7 +11,7 @@ namespace Take.Elephant.Sql
 {
     public class SqlExpressionTranslator : ExpressionVisitor
     {
-        public const string PARAMETER_COUNT_SEPARATOR = "$";
+        internal const string PARAMETER_COUNT_SEPARATOR = "$";
 
         private readonly StringBuilder _filter;
         private readonly IDictionary<string, object> _filterValues;

--- a/src/Take.Elephant.Sql/SqlExpressionTranslator.cs
+++ b/src/Take.Elephant.Sql/SqlExpressionTranslator.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.Common;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -12,6 +11,8 @@ namespace Take.Elephant.Sql
 {
     public class SqlExpressionTranslator : ExpressionVisitor
     {
+        public const string PARAMETER_COUNT_SEPARATOR = "$";
+
         private readonly StringBuilder _filter;
         private readonly IDictionary<string, object> _filterValues;
         private readonly IDatabaseDriver _databaseDriver;
@@ -83,7 +84,6 @@ namespace Take.Elephant.Sql
                     }
                     else
                     {
-
                         @operator = _databaseDriver.GetSqlStatementTemplate(SqlStatement.NotEqual);
                     }
                     break;
@@ -304,7 +304,7 @@ namespace Take.Elephant.Sql
                 name = _parameterNames.Dequeue();
                 if (_filterValues.ContainsKey(name))
                 {
-                    name = $"{name}{_parameterCount}";
+                    name = $"{name}{PARAMETER_COUNT_SEPARATOR}{_parameterCount}";
                 }
             }
 

--- a/src/Take.Elephant.Sql/SqlExtensions.cs
+++ b/src/Take.Elephant.Sql/SqlExtensions.cs
@@ -1,8 +1,8 @@
 ﻿using System.Collections.Generic;
 using System.Data;
 using System.Data.Common;
-using System.Data.SqlClient;
 using System.Linq;
+using System.Text.RegularExpressions;
 using Take.Elephant.Sql.Mapping;
 
 namespace Take.Elephant.Sql
@@ -23,7 +23,7 @@ namespace Take.Elephant.Sql
         {
             return databaseDriver.CreateParameter(databaseDriver.ParseParameterName(keyValuePair.Key), keyValuePair.Value);
         }
-        
+
         public static DbParameter ToDbParameter(this KeyValuePair<string, object> keyValuePair, IDatabaseDriver databaseDriver, SqlType sqlType)
         {
             return databaseDriver.CreateParameter(databaseDriver.ParseParameterName(keyValuePair.Key), keyValuePair.Value, sqlType);
@@ -31,17 +31,28 @@ namespace Take.Elephant.Sql
 
         public static DbParameter ToDbParameter(
             this KeyValuePair<string, object> keyValuePair,
-            IDatabaseDriver databaseDriver, 
+            IDatabaseDriver databaseDriver,
             IDictionary<string, SqlType> columnTypes)
         {
-            return columnTypes.TryGetValue(keyValuePair.Key, out var sqlType)
-                ? keyValuePair.ToDbParameter(databaseDriver, sqlType)
-                : keyValuePair.ToDbParameter(databaseDriver);
+            if (columnTypes.TryGetValue(keyValuePair.Key, out var sqlType))
+            {
+                return keyValuePair.ToDbParameter(databaseDriver, sqlType);
+            }
+            else
+            {
+                // Queries with multiples parameters for same column add a number to the end of parameter key.
+                // Try to get the sqlType for parameter removing the digits at the end of parameter key
+                var key = Regex.Replace(keyValuePair.Key, @"\d*$", string.Empty);
+
+                return columnTypes.TryGetValue(key, out var sqlType2)
+                    ? keyValuePair.ToDbParameter(databaseDriver, sqlType2)
+                    : keyValuePair.ToDbParameter(databaseDriver);
+            }
         }
 
         public static IEnumerable<DbParameter> ToDbParameters(
             this IDictionary<string, object> parameters,
-            IDatabaseDriver databaseDriver, 
+            IDatabaseDriver databaseDriver,
             ITable table)
         {
             return parameters.Select(p => p.ToDbParameter(databaseDriver, table.Columns));

--- a/src/Take.Elephant.Sql/SqlExtensions.cs
+++ b/src/Take.Elephant.Sql/SqlExtensions.cs
@@ -2,7 +2,6 @@
 using System.Data;
 using System.Data.Common;
 using System.Linq;
-using System.Text.RegularExpressions;
 using Take.Elephant.Sql.Mapping;
 
 namespace Take.Elephant.Sql

--- a/src/Take.Elephant.Sql/SqlExtensions.cs
+++ b/src/Take.Elephant.Sql/SqlExtensions.cs
@@ -9,8 +9,6 @@ namespace Take.Elephant.Sql
 {
     public static class SqlExtensions
     {
-        public const string PARAMETER_COUNT_SEPARATOR = "__";
-
         /// <summary>
         /// Transform to a flat string with comma separate values.
         /// </summary>

--- a/src/Take.Elephant.Tests/Sql/SqlExpressionTranslatorFacts.cs
+++ b/src/Take.Elephant.Tests/Sql/SqlExpressionTranslatorFacts.cs
@@ -18,7 +18,6 @@ namespace Take.Elephant.Tests.Sql
 
         public IDatabaseDriver DatabaseDriver { get; }
 
-
         public SqlExpressionTranslator GetTarget()
         {
             return new SqlExpressionTranslator(DatabaseDriver, DbTypeMapper.Default);
@@ -27,7 +26,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact]
         public void SingleEqualsConstantClauseShouldCreateSql()
         {
-            // Arrange            
+            // Arrange
             Expression<Func<Item, bool>> expression = i => i.StringProperty == "abcd";
             var target = GetTarget();
 
@@ -42,7 +41,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact]
         public void SingleEqualsConstantWithComplexTypeClauseShouldCreateSql()
         {
-            // Arrange            
+            // Arrange
             Expression<Func<TestItem, bool>> expression = i => i.Value3.ToString() == "XYZ";
             var target = GetTarget();
 
@@ -57,7 +56,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact]
         public void SingleContainsConstantClauseShouldCreateSql()
         {
-            // Arrange            
+            // Arrange
             Expression<Func<Item, bool>> expression = i => i.StringProperty.Contains("abcd");
             var target = GetTarget();
 
@@ -72,7 +71,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact]
         public void SingleStartsWithConstantClauseShouldCreateSql()
         {
-            // Arrange            
+            // Arrange
             Expression<Func<Item, bool>> expression = i => i.StringProperty.StartsWith("abcd");
             var target = GetTarget();
 
@@ -87,7 +86,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact]
         public void SingleEndsWithConstantClauseShouldCreateSql()
         {
-            // Arrange            
+            // Arrange
             Expression<Func<Item, bool>> expression = i => i.StringProperty.EndsWith("abcd");
             var target = GetTarget();
 
@@ -102,7 +101,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact]
         public void SingleEqualsWithSqlInjectionShouldBeHandled()
         {
-            // Arrange            
+            // Arrange
             Expression<Func<Item, bool>> expression = i => i.StringProperty == "abcd'); DROP TABLE MyTable; --";
             var target = GetTarget();
 
@@ -117,7 +116,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact]
         public void SingleEqualsExplicitBooleanConstantClauseShouldCreateSql()
         {
-            // Arrange            
+            // Arrange
             Expression<Func<Item, bool>> expression = i => i.BooleanProperty == false || i.BooleanProperty == true;
             var target = GetTarget();
 
@@ -125,15 +124,15 @@ namespace Take.Elephant.Tests.Sql
             var actual = target.GetStatement(expression);
 
             // Assert
-            AssertEquals(actual.Where, "(([BooleanProperty] = @BooleanProperty) OR ([BooleanProperty] = @BooleanProperty1))");
+            AssertEquals(actual.Where, "(([BooleanProperty] = @BooleanProperty) OR ([BooleanProperty] = @BooleanProperty$1))");
             AssertEquals(actual.FilterValues["BooleanProperty"], false);
-            AssertEquals(actual.FilterValues["BooleanProperty1"], true);
+            AssertEquals(actual.FilterValues["BooleanProperty$1"], true);
         }
 
         [Fact(Skip = "Not supported yet")]
         public void SingleEqualsBooleanConstantClauseShouldCreateSql()
         {
-            // Arrange            
+            // Arrange
             Expression<Func<Item, bool>> expression = i => i.BooleanProperty;
             var target = GetTarget();
 
@@ -148,7 +147,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact]
         public void SingleNotEqualsConstantClauseShouldCreateSql()
         {
-            // Arrange            
+            // Arrange
             Expression<Func<Item, bool>> expression = i => i.StringProperty != "abcd";
             var target = GetTarget();
 
@@ -163,7 +162,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact]
         public void SingleNullConstantClauseShouldCreateSql()
         {
-            // Arrange            
+            // Arrange
             Expression<Func<Item, bool>> expression = i => i.StringProperty == null;
             var target = GetTarget();
 
@@ -178,7 +177,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact]
         public void SingleNotNullConstantClauseShouldCreateSql()
         {
-            // Arrange            
+            // Arrange
             Expression<Func<Item, bool>> expression = i => i.StringProperty != null;
             var target = GetTarget();
 
@@ -193,7 +192,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact]
         public void SingleEqualsMemberClauseShouldCreateSql()
         {
-            // Arrange            
+            // Arrange
             var item = new Item
             {
                 StringProperty = "abcd"
@@ -213,7 +212,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact]
         public void SingleEqualsExternalMemberClauseShouldCreateSql()
         {
-            // Arrange            
+            // Arrange
             var item = new TestItem
             {
                 Value1 = "abcd",
@@ -234,7 +233,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact(Skip = "Not supported yet")]
         public void SingleEqualsNullMemberClauseShouldCreateSql()
         {
-            // Arrange            
+            // Arrange
             var item = new Item
             {
                 StringProperty = null
@@ -254,7 +253,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact]
         public void MultipleConstantsAndClausesShouldCreateSql()
         {
-            // Arrange            
+            // Arrange
             Expression<Func<Item, bool>> expression = i => i.StringProperty == "abcd" && i.IntegerProperty == 2 && i.RandomProperty == "random value";
             var target = GetTarget();
 
@@ -271,7 +270,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact]
         public void MultipleConstantsOrClausesShouldCreateSql()
         {
-            // Arrange            
+            // Arrange
             Expression<Func<Item, bool>> expression = i => i.StringProperty == "abcd" || i.IntegerProperty == 2 || i.RandomProperty == "random value";
             var target = GetTarget();
 
@@ -288,7 +287,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact]
         public void MultipleConstantsAndOrClausesShouldCreateSql()
         {
-            // Arrange            
+            // Arrange
             Expression<Func<Item, bool>> expression = i => i.StringProperty == "abcd" && i.IntegerProperty == 2 || i.RandomProperty.Contains("random value");
             var target = GetTarget();
 
@@ -305,7 +304,7 @@ namespace Take.Elephant.Tests.Sql
         [Fact]
         public void MultipleConstantAndMemberAccessAndClausesShouldCreateSql()
         {
-            // Arrange        
+            // Arrange
             var item = new Item
             {
                 StringProperty = "abcd",
@@ -324,8 +323,7 @@ namespace Take.Elephant.Tests.Sql
             AssertEquals(actual.FilterValues["RandomProperty"], "random value");
         }
 
-
-        class TestItem
+        private class TestItem
         {
             public string Value1 { get; set; }
 

--- a/src/Take.Elephant.Tests/Sql/SqlExtensionsFacts.cs
+++ b/src/Take.Elephant.Tests/Sql/SqlExtensionsFacts.cs
@@ -94,7 +94,7 @@ namespace Take.Elephant.Tests.Sql
             AssertEquals(actual[2].Size, 500);
 
             //Parameter with different name from the comparison field, automatic size by value length
-            AssertEquals(actual[3].ParameterName, "@PersonalField3");
+            AssertEquals(actual[3].ParameterName, $"@PersonalField$3");
             AssertEquals(actual[3].Value, param3);
             AssertEquals(actual[3].Direction, ParameterDirection.Input);
             AssertEquals(actual[3].DbType, DbType.String);

--- a/src/Take.Elephant.Tests/Sql/SqlExtensionsFacts.cs
+++ b/src/Take.Elephant.Tests/Sql/SqlExtensionsFacts.cs
@@ -19,7 +19,6 @@ namespace Take.Elephant.Tests.Sql
 
         public IDatabaseDriver DatabaseDriver { get; }
 
-
         public SqlWhereStatement GetTarget(Expression expression)
         {
             var sqlExpressionTranslator = new SqlExpressionTranslator(DatabaseDriver, DbTypeMapper.Default);
@@ -53,16 +52,16 @@ namespace Take.Elephant.Tests.Sql
             var param7 = true;
             var param8 = Guid.NewGuid();
 
-            // Arrange            
-            Expression<Func<FakeDocument, bool>> expression = i => 
-                i.Id == param0 && 
-                i.Name == param1 && 
+            // Arrange
+            Expression<Func<FakeDocument, bool>> expression = i =>
+                i.Id == param0 &&
+                i.Name == param1 &&
                 (i.PersonalField == param2 || i.PersonalField == param3) &&
                 i.DateProperty == param4 &&
                 (i.DecimalProperty == param5 || i.FloatProperty == param6) &&
                 i.BooleanProperty == param7 &&
                 i.GuidProperty == param8;
-            
+
             var target = GetTarget(expression);
 
             // Act
@@ -100,7 +99,7 @@ namespace Take.Elephant.Tests.Sql
             AssertEquals(actual[3].Direction, ParameterDirection.Input);
             AssertEquals(actual[3].DbType, DbType.String);
             AssertEquals(((SqlParameter)actual[3]).SqlDbType, SqlDbType.NVarChar);
-            AssertEquals(actual[3].Size, 5);
+            AssertEquals(actual[3].Size, 500);
 
             AssertEquals(actual[4].ParameterName, "@DateProperty");
             AssertEquals(actual[4].Value, param4);


### PR DESCRIPTION
Currently, when a sql query is done using the same column for multiple validations, the parameters generated for that column have a different type. This is caused by the fact that each parameter will have a number at the end. Like:

A query generated for the query `(Ticket t) => t.status == 'Open'  || t.status == 'Closed'` will generate the params `@Status `and `@Status3` (don't ask me why 3). 

The ideia here is guarantee all parameters will be successfully typed according the equivalent type and size.