### PR TITLE
Update Kafka libs

### DIFF
--- a/src/Take.Elephant.Kafka/Take.Elephant.Kafka.csproj
+++ b/src/Take.Elephant.Kafka/Take.Elephant.Kafka.csproj
@@ -21,8 +21,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Confluent.Kafka" Version="1.3.0" />
-    <PackageReference Include="librdkafka.redist" Version="1.3.0" />
+    <PackageReference Include="Confluent.Kafka" Version="1.6.3" />
+    <PackageReference Include="librdkafka.redist" Version="1.6.1" />
     <PackageReference Include="System.Threading.Channels" Version="4.7.0" />
   </ItemGroup>
 

--- a/src/Take.Elephant.Tests/Kafka/KafkaItemSenderReceiverQueueFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaItemSenderReceiverQueueFacts.cs
@@ -1,11 +1,9 @@
 using Confluent.Kafka;
 using System;
-using System.IO;
 using System.Linq;
-using Confluent.Kafka.Admin;
 using Take.Elephant.Kafka;
-using Xunit;
 using Take.Elephant.Tests.Azure;
+using Xunit;
 
 namespace Take.Elephant.Tests.Kafka
 {


### PR DESCRIPTION
This PR updates Confluent.Kafka and librdkafka.redist version to the latest one in order to solve a bug in the earlier versions (https://github.com/edenhill/librdkafka/issues/2782). 