### PR TITLE
Revert sql client update

### DIFF
--- a/src/Take.Elephant.Sql/Take.Elephant.Sql.csproj
+++ b/src/Take.Elephant.Sql/Take.Elephant.Sql.csproj
@@ -18,7 +18,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.8.2" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
Latest System.Data.SqlClient presents blocking issues for some users, so this PR reverts back to previous published version.
This seems related to [this issue](https://github.com/dotnet/SqlClient/issues/85), which seems that will be only fixed on new Microsoft.Data.SqlClient.