### PR TITLE
Resubscribe on unhandled exceptions on ConsumeAsync

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ UpdatableMap     | Map    | Map that supports value updates under specific condi
 * [Take.Elephant.Sql](https://nuget.org/packages/Take.Elephant.Sql/)
 * [Take.Elephant.Sql.PostgreSql](https://nuget.org/packages/Take.Elephant.Sql.PostgreSql/)
 * [Take.Elephant.Azure](https://nuget.org/packages/Take.Elephant.Azure/)
+* [Take.Elephant.Kafka](https://nuget.org/packages/Take.Elephant.Kafka/)
 
 ### Samples
 


### PR DESCRIPTION
Exceptions thrown during subscription to the kafka topic were not handled, causing the ConsumeAsync Task to die and the consumer to starve, as the channel was no longer filled.

In this new solution, unhandled exceptions causes the consumer to resubscribe to the topic, so it won't starve. 