### PR TITLE
ExpirableKeySqlMap.ContainsKeyAsync now also uses expiration logic & add new tests

### DIFF
--- a/src/Take.Elephant.Sql/DbDataReaderAsyncEnumerator.cs
+++ b/src/Take.Elephant.Sql/DbDataReaderAsyncEnumerator.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Data.Common;
+using System.Data.SqlClient;
 using System.Threading;
 using System.Threading.Tasks;
 using Take.Elephant.Sql.Mapping;

--- a/src/Take.Elephant.Sql/ExpirableKeySqlMap.ExpirationDatabaseDriverDecorator.cs
+++ b/src/Take.Elephant.Sql/ExpirableKeySqlMap.ExpirationDatabaseDriverDecorator.cs
@@ -6,7 +6,6 @@ using System.Runtime.CompilerServices;
 using System.Text.RegularExpressions;
 using Take.Elephant.Sql.Mapping;
 
-[assembly: InternalsVisibleTo("Take.Elephant.Tests")]
 namespace Take.Elephant.Sql
 {
     public partial class ExpirableKeySqlMap<TKey, TValue>
@@ -64,22 +63,9 @@ namespace Take.Elephant.Sql
 
             public string DefaultSchema => _underlyingDatabaseDriver.DefaultSchema;
 
-            private static string InjectSqlFilter(string sql, string filter)
+            private static string InjectSqlFilter(string sql, string filterToInject)
             {
-                if (sql.Contains("ORDER BY"))
-                    return sql.Replace("ORDER BY", $"{filter} ORDER BY");
-                if (sql.StartsWith("SELECT CASE WHEN EXISTS", StringComparison.InvariantCultureIgnoreCase))
-                {
-                    var regex = new Regex(@"(SELECT CASE WHEN EXISTS \(\()(.*?)(\))(.*?)(END)");
-                    var matches = regex.Matches(sql);
-                    if (matches.Any())
-                    {
-                        var captureGroups = matches.First().Groups;
-                        // first group is always the entire string, so we can skip that
-                        return $"{captureGroups[1]}{captureGroups[2]} {filter}{captureGroups[3]}{captureGroups[4]}{captureGroups[5]}";
-                    }
-                }
-                return $"{sql} {filter}";
+                return sql.Replace("WHERE {filter}", $"WHERE ({{filter}}) {filterToInject}");
             }
         }
     }

--- a/src/Take.Elephant.Sql/Properties/AssemblyInfo.cs
+++ b/src/Take.Elephant.Sql/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+﻿using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Take.Elephant.Tests")]

--- a/src/Take.Elephant.Tests/ExpirableKeyMapFacts.cs
+++ b/src/Take.Elephant.Tests/ExpirableKeyMapFacts.cs
@@ -40,8 +40,8 @@ namespace Take.Elephant.Tests
             await Task.Delay(ttl + ttl);
 
             // Assert
-            var actual = await map.GetValueOrDefaultAsync(key);
-            AssertIsDefault(actual);
+            var contains = await map.ContainsKeyAsync(key);
+            AssertIsFalse(contains);
         }
 
         [Fact(DisplayName = "ExpireExistingKeyByAbsoluteExpirationDateSucceeds")]
@@ -60,8 +60,8 @@ namespace Take.Elephant.Tests
             await Task.Delay(ttl + ttl);
 
             // Assert
-            var actual = await map.GetValueOrDefaultAsync(key);
-            AssertIsDefault(actual);
+            var contains = await map.ContainsKeyAsync(key);
+            AssertIsDefault(contains);
         }
 
         [Fact(DisplayName = "UpdateKeyTtlSucceeds")]
@@ -76,15 +76,16 @@ namespace Take.Elephant.Tests
             await map.SetRelativeKeyExpirationAsync(key, ttl);
 
             // Act
-            await map.SetRelativeKeyExpirationAsync(key, ttl + ttl + ttl);
+            var newTtl = ttl * 3;
+            await map.SetRelativeKeyExpirationAsync(key, newTtl);
 
             // Assert
             await Task.Delay(ttl);
             var actual = await map.GetValueOrDefaultAsync(key);
             AssertEquals(actual, value);
-            await Task.Delay(ttl + ttl + ttl);
-            actual = await map.GetValueOrDefaultAsync(key);
-            AssertIsDefault(actual);
+            await Task.Delay(newTtl);
+            var contains = await map.ContainsKeyAsync(key);
+            AssertIsFalse(contains);
         }
 
         [Fact(DisplayName = "UpdateKeyExpirationDateSucceeds")]
@@ -109,8 +110,8 @@ namespace Take.Elephant.Tests
             var actual = await map.GetValueOrDefaultAsync(key);
             AssertEquals(actual, value);
             await Task.Delay(ttl + ttl + ttl);
-            actual = await map.GetValueOrDefaultAsync(key);
-            AssertIsDefault(actual);
+            var contains = await map.ContainsKeyAsync(key);
+            AssertIsDefault(contains);
         }
 
         [Fact(DisplayName = nameof(ExpireInvalidKeyByRelativeTtlReturnsFalse))]

--- a/src/Take.Elephant.Tests/ExpirableKeyMapFacts.cs
+++ b/src/Take.Elephant.Tests/ExpirableKeyMapFacts.cs
@@ -57,11 +57,11 @@ namespace Take.Elephant.Tests
 
             // Act
             await map.SetAbsoluteKeyExpirationAsync(key, expiration);
-            await Task.Delay(ttl + ttl);
+            await Task.Delay(ttl * 2);
 
             // Assert
             var contains = await map.ContainsKeyAsync(key);
-            AssertIsDefault(contains);
+            AssertIsFalse(contains);
         }
 
         [Fact(DisplayName = "UpdateKeyTtlSucceeds")]
@@ -111,7 +111,7 @@ namespace Take.Elephant.Tests
             AssertEquals(actual, value);
             await Task.Delay(ttl + ttl + ttl);
             var contains = await map.ContainsKeyAsync(key);
-            AssertIsDefault(contains);
+            AssertIsFalse(contains);
         }
 
         [Fact(DisplayName = nameof(ExpireInvalidKeyByRelativeTtlReturnsFalse))]

--- a/src/Take.Elephant.Tests/Sql/ExpirationDatabaseDriverDecoratorFacts.cs
+++ b/src/Take.Elephant.Tests/Sql/ExpirationDatabaseDriverDecoratorFacts.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using NSubstitute;
+using Take.Elephant.Sql;
+using Xunit;
+
+namespace Take.Elephant.Tests.Sql
+{
+    public class ExpirationDatabaseDriverDecoratorFacts : FactsBase
+    {
+        private readonly IDatabaseDriver _databaseDriver;
+
+
+        public ExpirationDatabaseDriverDecoratorFacts()
+        {
+            _databaseDriver = Substitute.For<IDatabaseDriver>();
+        }
+
+        [Theory]
+        [InlineData(SqlStatement.Select)]
+        [InlineData(SqlStatement.SelectCount)]
+        [InlineData(SqlStatement.SelectTop1)]
+        [InlineData(SqlStatement.SelectSkipTake)]
+        [InlineData(SqlStatement.SelectDistinct)]
+        [InlineData(SqlStatement.SelectCountDistinct)]
+        [InlineData(SqlStatement.SelectDistinctSkipTake)]
+        [InlineData(SqlStatement.Exists)]
+        public async Task GetSqlStatementTemplateMustBeIdempotent(SqlStatement statement)
+        {
+            // ExpirationDatabaseDriverDecorator.GetSqlStatementTemplate should inject a parameterized query
+            // so that multiple calls to it with the same arguments should always yield the exact same query
+            // in order not to thrash the database's plan cache
+
+            // Arrange
+            var decorator = new ExpirableKeySqlMap<int, int>.ExpirationDatabaseDriverDecorator(_databaseDriver, "ExpirationDate");
+
+            // Act
+            var template1 = decorator.GetSqlStatementTemplate(statement);
+            await Task.Delay(TimeSpan.FromSeconds(1));
+            var template2 = decorator.GetSqlStatementTemplate(statement);
+
+            // Assert
+            Assert.Equal(template2, template1);
+        }
+    }
+}


### PR DESCRIPTION
`ExpirableKeySqlMap.ContainsKeyAsync` before this change would ignore the expiration logic, meaning that whether or not an item had expired would have no effect on the return of that method. Because of that, `GetItemOrDefaultAsync` and `ContainsKeyAsync` had inconsistent behavior.

This PR fixes that by altering the filter injection logic to also work with `Exists` Sql statements.

Instead of adding new tests, I've decided to change the existing ones to use `ContainsKeyAsync`, as I think that is a more proper method for what is being checked in most of the tests - first because they're not using the return value from `GetItemOrDefaultAsync` and second because the way they used to test whether or not the map returned an item was testing against the `default` value for the type, even though that could be a legitimate value (which, in my opinion, makes the test prone to coding errors). In fact, the reason I noticed the faulty behavior within `ContainsKeyAsync` was by starting to refactor those tests to use it! 😅

I've also taken the opportunity to introduce new tests to `ExpirableKeySqlMap.ExpirationDatabaseDriverDecorator.GetSqlStatementTemplate` in order to catch the issue we had previously with plan cache thrashing. 