### PR TITLE
Feature/message id into kafka sender queue

### DIFF
--- a/src/Take.Elephant.Kafka/KafkaQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaQueue.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Take.Elephant.Kafka
 {
-    public class KafkaQueue<T> : IBlockingQueue<T>, ICloseable, IDisposable
+    public class KafkaQueue<T> : IBlockingQueue<T>, ICloseable, IDisposable, IBlockingStreamQueue<T>
     {
         private readonly KafkaSenderQueue<T> _senderQueue;
         private readonly KafkaReceiverQueue<T> _receiverQueue;
@@ -25,6 +25,11 @@ namespace Take.Elephant.Kafka
         public virtual Task EnqueueAsync(T item, CancellationToken cancellationToken = default)
         {
             return _senderQueue.EnqueueAsync(item, cancellationToken);
+        }
+
+        public virtual Task EnqueueAsync(T item, string messageId, CancellationToken cancellationToken = default)
+        {
+            return _senderQueue.EnqueueAsync(item, messageId, cancellationToken);
         }
 
         public virtual Task<T> DequeueAsync(CancellationToken cancellationToken)

--- a/src/Take.Elephant.Kafka/KafkaQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaQueue.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Take.Elephant.Kafka
 {
-    public class KafkaQueue<T> : IBlockingQueue<T>, ICloseable, IDisposable, IBlockingStreamQueue<T>
+    public class KafkaQueue<T> : IBlockingStreamQueue<T>, ICloseable, IDisposable
     {
         private readonly KafkaSenderQueue<T> _senderQueue;
         private readonly KafkaReceiverQueue<T> _receiverQueue;

--- a/src/Take.Elephant.Kafka/KafkaSenderQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaSenderQueue.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Take.Elephant.Kafka
 {
-    public class KafkaSenderQueue<T> : ISenderQueue<T>, IDisposable, IStreamSenderQueue<T>
+    public class KafkaSenderQueue<T> : ISenderQueue<T>, IDisposable
     {
         private readonly IProducer<Null, string> _producer;
         private readonly IProducer<string, string> _producerKey;

--- a/src/Take.Elephant.Kafka/KafkaSenderQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaSenderQueue.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 
 namespace Take.Elephant.Kafka
 {
-    public class KafkaSenderQueue<T> : ISenderQueue<T>, IDisposable
+    public class KafkaSenderQueue<T> : IStreamSenderQueue<T>, IDisposable
     {
         private readonly IProducer<Null, string> _producer;
         private readonly IProducer<string, string> _producerKey;

--- a/src/Take.Elephant.Tests/Kafka/KafkaItemSenderReceiverQueueFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaItemSenderReceiverQueueFacts.cs
@@ -10,7 +10,7 @@ namespace Take.Elephant.Tests.Kafka
     [Trait("Category", nameof(Kafka))]
     public class KafkaItemSenderReceiverQueueFacts : ItemSenderReceiverQueueFacts
     {
-        public override (ISenderQueue<Item>, IBlockingReceiverQueue<Item>) Create()
+        public override (IStreamSenderQueue<Item>, IBlockingReceiverQueue<Item>) Create()
         {
             ClientConfig clientConfig;
             var topic = "items";

--- a/src/Take.Elephant.Tests/Memory/MemoryItemSenderReceiverQueueFacts.cs
+++ b/src/Take.Elephant.Tests/Memory/MemoryItemSenderReceiverQueueFacts.cs
@@ -6,9 +6,9 @@ namespace Take.Elephant.Tests.Memory
     [Trait("Category", nameof(Memory))]
     public class MemoryItemSenderReceiverQueueFacts : ItemSenderReceiverQueueFacts
     {
-        public override (ISenderQueue<Item>, IBlockingReceiverQueue<Item>) Create()
+        public override (IStreamSenderQueue<Item>, IBlockingReceiverQueue<Item>) Create()
         {
-            var queue = new Queue<Item>();
+            var queue = new StreamQueue<Item>();
             return (queue, queue);
         }
     }

--- a/src/Take.Elephant.Tests/SenderReceiverQueueFacts.cs
+++ b/src/Take.Elephant.Tests/SenderReceiverQueueFacts.cs
@@ -18,7 +18,7 @@ namespace Take.Elephant.Tests
             _cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
         }
 
-        public abstract (ISenderQueue<T>, IBlockingReceiverQueue<T>) Create();
+        public abstract (IStreamSenderQueue<T>, IBlockingReceiverQueue<T>) Create();
 
         public CancellationToken CancellationToken => _cts.Token;
 
@@ -36,6 +36,21 @@ namespace Take.Elephant.Tests
 
             // Act
             await senderQueue.EnqueueAsync(item, CancellationToken);
+
+            // Assert
+            AssertEquals(await receiverQueue.DequeueAsync(CancellationToken), item);
+        }
+
+        [Fact(DisplayName = nameof(EnqueueNewItemWithIdSucceeds))]
+        public virtual async Task EnqueueNewItemWithIdSucceeds()
+        {
+            // Arrange
+            var (senderQueue, receiverQueue) = Create();
+            var item = CreateItem();
+            var id = Guid.NewGuid().ToString();
+
+            // Act
+            await senderQueue.EnqueueAsync(item, id, CancellationToken);
 
             // Assert
             AssertEquals(await receiverQueue.DequeueAsync(CancellationToken), item);

--- a/src/Take.Elephant/IBlockingStreamQueue.cs
+++ b/src/Take.Elephant/IBlockingStreamQueue.cs
@@ -6,8 +6,8 @@ using System.Threading.Tasks;
 
 namespace Take.Elephant
 {
-    public interface IBlockingStreamQueue<T> : IBlockingQueue<T>
+    public interface IBlockingStreamQueue<T> : IBlockingQueue<T>, IStreamSenderQueue<T>
     {
-        Task EnqueueAsync(T item, string id, CancellationToken cancellationToken = default(CancellationToken));
+
     }
 }

--- a/src/Take.Elephant/IBlockingStreamQueue.cs
+++ b/src/Take.Elephant/IBlockingStreamQueue.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Take.Elephant
+{
+    public interface IBlockingStreamQueue<T> : IBlockingQueue<T>
+    {
+        Task EnqueueAsync(T item, string id, CancellationToken cancellationToken = default(CancellationToken));
+    }
+}

--- a/src/Take.Elephant/IQueue.cs
+++ b/src/Take.Elephant/IQueue.cs
@@ -39,6 +39,18 @@ namespace Take.Elephant
         Task EnqueueAsync(T item, CancellationToken cancellationToken = default);
     }
 
+    public interface IStreamSenderQueue<T>
+    {
+        /// <summary>
+        /// Enqueues an item.
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="messageId"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task EnqueueAsync(T item, string messageId, CancellationToken cancellationToken = default);
+    }
+
     public interface IBatchSenderQueue<T>
     {
         /// <summary>

--- a/src/Take.Elephant/IQueue.cs
+++ b/src/Take.Elephant/IQueue.cs
@@ -39,6 +39,18 @@ namespace Take.Elephant
         Task EnqueueAsync(T item, CancellationToken cancellationToken = default);
     }
 
+    public interface IStreamSenderQueue<T>: ISenderQueue<T>
+    {
+        /// <summary>
+        /// Enqueues an item.
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="id"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task EnqueueAsync(T item, string id, CancellationToken cancellationToken = default);
+    }
+
     public interface IBatchSenderQueue<T>
     {
         /// <summary>

--- a/src/Take.Elephant/IQueue.cs
+++ b/src/Take.Elephant/IQueue.cs
@@ -39,18 +39,6 @@ namespace Take.Elephant
         Task EnqueueAsync(T item, CancellationToken cancellationToken = default);
     }
 
-    public interface IStreamSenderQueue<T>
-    {
-        /// <summary>
-        /// Enqueues an item.
-        /// </summary>
-        /// <param name="item"></param>
-        /// <param name="messageId"></param>
-        /// <param name="cancellationToken"></param>
-        /// <returns></returns>
-        Task EnqueueAsync(T item, string messageId, CancellationToken cancellationToken = default);
-    }
-
     public interface IBatchSenderQueue<T>
     {
         /// <summary>

--- a/src/Take.Elephant/Memory/StreamQueue.cs
+++ b/src/Take.Elephant/Memory/StreamQueue.cs
@@ -1,14 +1,12 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using System.Threading;
+﻿using System.Threading;
 using System.Threading.Tasks;
 
 namespace Take.Elephant.Memory
 {
-    public class StreamQueue<T> : Queue<T>, IBlockingStreamQueue<T>
+    public class StreamQueue<T> : Queue<T>, IStreamSenderQueue<T>
     {
         public StreamQueue() : base() { }
+
         public virtual Task EnqueueAsync(T item, string id, CancellationToken cancellationToken = default(CancellationToken))
         {
            return EnqueueAsync(item, cancellationToken);

--- a/src/Take.Elephant/Memory/StreamQueue.cs
+++ b/src/Take.Elephant/Memory/StreamQueue.cs
@@ -1,0 +1,18 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Take.Elephant.Memory
+{
+    public class StreamQueue<T> : Queue<T>, IBlockingStreamQueue<T>
+    {
+        public StreamQueue() : base() { }
+        public virtual Task EnqueueAsync(T item, string id, CancellationToken cancellationToken = default(CancellationToken))
+        {
+           return EnqueueAsync(item, cancellationToken);
+        }
+    }
+}
+


### PR DESCRIPTION
- Implementation of a new Kafka enqueue method, that allows sending the message ID as the Key to the queue. A Id was added to the other enqueue method with a Guid generator