### PR TITLE
Fix wrong unconditional call to Dispose on ExpirationDbConnectionDecorator

### DIFF
--- a/src/Take.Elephant.Sql/ExpirableKeySqlMap.ExpirationDbConnectionDecorator.cs
+++ b/src/Take.Elephant.Sql/ExpirableKeySqlMap.ExpirationDbConnectionDecorator.cs
@@ -65,7 +65,10 @@ namespace Take.Elephant.Sql
             protected override void Dispose(bool disposing)
             {
                 base.Dispose(disposing);
-                _dbConnection.Dispose();
+                if (disposing)
+                {
+                    _dbConnection.Dispose();
+                }
             }
 
             protected override DbTransaction BeginDbTransaction(IsolationLevel isolationLevel)


### PR DESCRIPTION
https://stackoverflow.com/questions/22962742/internal-net-framework-data-provider-error-1

I encountered the error mentioned in question when testing Iris. The call stack pointed to the `Dispose` method on the `ExpirableKeySqlMap.ExpirationDbConnectionDecorator` class. More specifically, I encountered the error when trying to initialize a `SqlMap` with invalid column names (the referenced `InvalidOperationException` was hiding this, though, and I had to do some digging to find the actual error), but I would guess that this is happening any time objects of this type are being finalized.

The linked question has an accepted answer on which there is a comment that explains that:

>You can also run into this indirectly in your Dispose() method if you unconditionally dispose of the connection. You should only dispose of it if (disposing)

The quoted warning comes from here:

https://docs.microsoft.com/en-us/dotnet/api/microsoft.data.sqlclient.sqldatareader.close?view=sqlclient-dotnet-core-3.0#remarks

Thus, fixing.