### PR TITLE
Feature/particioned kafka stream

### DIFF
--- a/src/Take.Elephant.Kafka/PartitionedKafkaReceiver.cs
+++ b/src/Take.Elephant.Kafka/PartitionedKafkaReceiver.cs
@@ -1,0 +1,177 @@
+using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Threading;
+using System.Threading.Channels;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+
+namespace Take.Elephant.Kafka
+{
+    public class PartitionedKafkaReceiver<TKey, TEvent> : IEventStreamConsumer<TKey, TEvent>, IOpenable, ICloseable, IDisposable
+    {
+        private readonly IConsumer<TKey, TEvent> _partitionedConsumer;
+        private readonly SemaphoreSlim _consumerStartSemaphore;
+        private readonly CancellationTokenSource _cts;
+        private readonly Channel<TEvent> _channel;
+        private Task _consumerTask;
+        private bool _closed;
+
+        public PartitionedKafkaReceiver(string bootstrapServers, string topic, string groupId, ISerializer<TEvent> serializer, IDeserializer<TEvent> deserializer = null)
+            : this(new ConsumerConfig() { BootstrapServers = bootstrapServers, GroupId = groupId }, topic, serializer, deserializer)
+        {
+        }
+
+        public PartitionedKafkaReceiver(
+            ConsumerConfig consumerConfig,
+            string topic,
+            ISerializer<TEvent> serializer,
+            IDeserializer<TEvent> deserializer = null)
+            : this(
+                  new ConsumerBuilder<TKey, TEvent>(consumerConfig)
+                      .SetValueDeserializer(deserializer ?? new Deserializer<TEvent>(serializer))
+                      .Build(),
+                    serializer,
+                  topic)
+        {
+        }
+
+        public PartitionedKafkaReceiver(IConsumer<TKey, TEvent> consumer, ISerializer<TEvent> serializer, string topic)
+        {
+            if (string.IsNullOrWhiteSpace(topic))
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(topic));
+            _partitionedConsumer = consumer ?? throw new ArgumentNullException(nameof(consumer));
+            Topic = topic;
+            _consumerStartSemaphore = new SemaphoreSlim(1, 1);
+            _cts = new CancellationTokenSource();
+            _channel = Channel.CreateBounded<TEvent>(1);
+        }
+
+        public string Topic { get; }
+
+        public virtual async Task<(TKey key, TEvent item)> ConsumeAsync(TKey key, CancellationToken cancellationToken)
+        {
+            await StartConsumerTaskIfNotAsync(cancellationToken);
+            if (_channel.Reader.TryRead(out var item))
+            {
+                return (key, item);
+            }
+
+            return default;
+        }
+
+        public Task OpenAsync(CancellationToken cancellationToken)
+        {
+            return StartConsumerTaskIfNotAsync(cancellationToken);
+        }
+
+        public virtual Task CloseAsync(CancellationToken cancellationToken)
+        {
+            if (!_closed)
+            {
+                _partitionedConsumer.Close();
+                _closed = true;
+            }
+
+            return _consumerTask;
+        }
+
+        public event EventHandler<ExceptionEventArgs> ConsumerFailed;
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                if (!_closed)
+                {
+                    _partitionedConsumer.Close();
+                }
+
+                _partitionedConsumer.Dispose();
+                _cts.Dispose();
+            }
+        }
+
+        private async Task StartConsumerTaskIfNotAsync(CancellationToken cancellationToken)
+        {
+            if (_consumerTask != null)
+                return;
+
+            await _consumerStartSemaphore.WaitAsync(cancellationToken);
+            try
+            {
+                if (_consumerTask == null)
+                {
+                    _consumerTask = Task
+                        .Factory
+                        .StartNew(
+                            () => ConsumeAsync(_cts.Token),
+                            TaskCreationOptions.LongRunning)
+                        .Unwrap();
+                }
+            }
+            finally
+            {
+                _consumerStartSemaphore.Release();
+            }
+        }
+
+        private async Task ConsumeAsync(CancellationToken cancellationToken)
+        {
+            if (_partitionedConsumer.Subscription.All(s => s != Topic))
+            {
+                _partitionedConsumer.Subscribe(Topic);
+            }
+
+            while (!cancellationToken.IsCancellationRequested)
+            {
+                try
+                {
+                    var result = _partitionedConsumer.Consume(cancellationToken);
+                    await _channel.Writer.WriteAsync(result.Message.Value, cancellationToken);
+                }
+                catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
+                {
+                    break;
+                }
+                catch (Exception ex)
+                {
+                    var handler = ConsumerFailed;
+                    if (handler != null)
+                    {
+                        handler.Invoke(this, new ExceptionEventArgs(ex));
+                    }
+                    else
+                    {
+                        Trace.TraceError("An unhandled exception occurred on KafkaReceiverQueue: {0}", ex);
+                    }
+                }
+            }
+
+            _partitionedConsumer.Unsubscribe();
+            _channel.Writer.Complete();
+        }
+
+        public void Dispose()
+        {
+            _partitionedConsumer.Close();
+            _partitionedConsumer.Dispose();
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        public class Deserializer<T> : IDeserializer<T>
+        {
+            private readonly ISerializer<T> _serializer;
+
+            public Deserializer(ISerializer<T> serializer)
+            {
+                _serializer = serializer;
+            }
+            public T Deserialize(ReadOnlySpan<byte> data, bool isNull, SerializationContext context)
+            {
+                return _serializer.Deserialize(Deserializers.Utf8.Deserialize(data, isNull, context));
+            }
+        }
+    }
+}

--- a/src/Take.Elephant.Kafka/PartitionedKafkaSender.cs
+++ b/src/Take.Elephant.Kafka/PartitionedKafkaSender.cs
@@ -9,7 +9,6 @@ namespace Take.Elephant.Kafka
     public class PartitionedKafkaSender<TKey, TEvent> : IEventStreamPublisher<TKey, TEvent>, IDisposable
     {
         private readonly IProducer<TKey, TEvent> _producer;
-        private readonly ISerializer<TEvent> _serializer;
 
         public PartitionedKafkaSender(string bootstrapServers, string topic, ISerializer<TEvent> serializer, Confluent.Kafka.ISerializer<TEvent> kafkaSerializer = null)
             : this(new ProducerConfig() { BootstrapServers = bootstrapServers }, topic, serializer, kafkaSerializer)

--- a/src/Take.Elephant.Kafka/PartitionedKafkaSender.cs
+++ b/src/Take.Elephant.Kafka/PartitionedKafkaSender.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+
+namespace Take.Elephant.Kafka
+{
+    public class PartitionedKafkaSender<TKey, TEvent> : IEventStreamPublisher<TKey, TEvent>, IDisposable
+    {
+        private readonly IProducer<TKey, TEvent> _producer;
+
+        public PartitionedKafkaSender(string bootstrapServers, string topic)
+            : this(new ProducerConfig() { BootstrapServers = bootstrapServers }, topic)
+        {
+        }
+
+        public PartitionedKafkaSender(
+            ProducerConfig producerConfig,
+            string topic)
+            : this(
+                  new ProducerBuilder<TKey, TEvent>(producerConfig)
+                        .Build(),
+                  topic)
+        {
+        }
+
+        public PartitionedKafkaSender(
+            IProducer<TKey, TEvent> producer,
+            string topic)
+        {
+            if (string.IsNullOrWhiteSpace(topic))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(topic));
+            }
+
+            _producer = producer;
+            Topic = topic;
+        }
+
+        public string Topic { get; }
+
+        public Task PublishAsync(TKey key, TEvent item, CancellationToken cancellationToken)
+        {
+            return _producer.ProduceAsync(
+                Topic,
+                new Message<TKey, TEvent>
+                {
+                    Key = key,
+                    Value = item
+                });
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _producer?.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Take.Elephant.Tests/ItemSenderReceiverStreamFacts.cs
+++ b/src/Take.Elephant.Tests/ItemSenderReceiverStreamFacts.cs
@@ -1,0 +1,10 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Take.Elephant.Tests
+{
+    public abstract class ItemSenderReceiverStreamFacts: PartitionedSenderReceiverFacts<string, Item>
+    {
+    }
+}

--- a/src/Take.Elephant.Tests/Kafka/KafkaPartitionedSenderReceiverStreamFacts .cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaPartitionedSenderReceiverStreamFacts .cs
@@ -68,7 +68,7 @@ namespace Take.Elephant.Tests.Kafka
                 consumer.Close();
             }
 
-            var senderQueue = new PartitionedKafkaSender<string, Item>(new ProducerConfig(clientConfig), topic);
+            var senderQueue = new PartitionedKafkaSender<string, Item>(new ProducerConfig(clientConfig), topic, new JsonItemSerializer());
             var receiverQueue = new PartitionedKafkaReceiver<string, Item>(consumerConfig, topic, new JsonItemSerializer());
             receiverQueue.OpenAsync(CancellationToken).Wait();
             return (senderQueue, receiverQueue);

--- a/src/Take.Elephant.Tests/PartitionedSenderReceiverFacts .cs
+++ b/src/Take.Elephant.Tests/PartitionedSenderReceiverFacts .cs
@@ -1,0 +1,134 @@
+using AutoFixture;
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Take.Elephant.Tests
+{
+    public abstract class PartitionedSenderReceiverFacts<TKey, TEvent> : FactsBase, IDisposable
+    {
+        private readonly CancellationTokenSource _cts;
+
+        public PartitionedSenderReceiverFacts()
+        {
+            _cts = new CancellationTokenSource(TimeSpan.FromSeconds(30));
+        }
+
+        public abstract (IEventStreamPublisher<string, Item>, IEventStreamConsumer<string, Item>) CreateStream();
+
+        public CancellationToken CancellationToken => _cts.Token;
+
+        protected virtual Item CreateItem()
+        {
+            return Fixture.Create<Item>();
+        }
+
+        [Fact(DisplayName = nameof(PublishNewItemSucceeds))]
+        public virtual async Task PublishNewItemSucceeds()
+        {
+            // Arrange
+            var (senderQueue, receiverQueue) = CreateStream();
+            var item = CreateItem();
+            var key = Guid.NewGuid().ToString();
+
+            // Act
+            await senderQueue.PublishAsync(key, item, CancellationToken);
+
+            // Assert
+            AssertEquals((key, item), await receiverQueue.ConsumeAsync(key, CancellationToken));
+        }
+
+        [Fact(DisplayName = nameof(EnqueueExistingItemSucceeds))]
+        public virtual async Task EnqueueExistingItemSucceeds()
+        {
+            // Arrange
+            var (senderQueue, receiverQueue) = CreateStream();
+            var item = CreateItem();
+            var key = Guid.NewGuid().ToString();
+
+            // Act
+            await senderQueue.PublishAsync(key, item, CancellationToken);
+            await senderQueue.PublishAsync(key, item, CancellationToken);
+
+            // Assert
+            AssertEquals((key, item), await receiverQueue.ConsumeAsync(key, CancellationToken));
+            AssertEquals((key, item), await receiverQueue.ConsumeAsync(key, CancellationToken));
+        }
+
+        //[Fact(DisplayName = nameof(EnqueueMultipleItemsSucceeds))]
+        //public virtual async Task EnqueueMultipleItemsSucceeds()
+        //{
+        //    // Arrange
+        //    var (senderQueue, receiverQueue) = CreateStream();
+        //    var items = new ConcurrentBag<T>();
+        //    var count = 100;
+        //    for (int i = 0; i < count; i++)
+        //    {
+        //        var item = CreateItem();
+        //        items.Add(item);
+        //    }
+
+        //    // Act
+        //    var enumerator = items.GetEnumerator();
+        //    var tasks = Enumerable
+        //        .Range(0, count)
+        //        .Where(_ => enumerator.MoveNext())
+        //        .Select(_ => Task.Run(async () => await senderQueue.EnqueueAsync(enumerator.Current, CancellationToken)));
+
+        //    await Task.WhenAll(tasks);
+
+        //    // Assert
+
+        //    foreach (var itemBag in items)
+        //    {
+        //        var item = await receiverQueue.DequeueAsync(CancellationToken);
+        //        if (item == null)
+        //        {
+        //            break;
+        //        }
+
+        //        AssertIsTrue(items.Contains(item));
+        //    }
+        //}
+
+        //[Fact(DisplayName = nameof(DequeueEmptyReturnsDefault))]
+        //public virtual async Task DequeueEmptyReturnsDefault()
+        //{
+        //    // Arrange
+        //    var (senderQueue, receiverQueue) = CreateStream();
+
+        //    // Act
+        //    T actual;
+
+        //    try
+        //    {
+        //        actual = await receiverQueue.DequeueAsync(CancellationToken);
+        //    }
+        //    catch (OperationCanceledException) when (CancellationToken.IsCancellationRequested)
+        //    {
+        //        actual = default;
+        //    }
+
+        //    // Assert
+        //    AssertIsDefault(actual);
+        //}
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _cts?.Dispose();
+            }
+        }
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+    }
+}

--- a/src/Take.Elephant.Tests/PartitionedSenderReceiverFacts .cs
+++ b/src/Take.Elephant.Tests/PartitionedSenderReceiverFacts .cs
@@ -42,8 +42,8 @@ namespace Take.Elephant.Tests
             AssertEquals((key, item), await receiverQueue.ConsumeAsync(key, CancellationToken));
         }
 
-        [Fact(DisplayName = nameof(EnqueueExistingItemSucceeds))]
-        public virtual async Task EnqueueExistingItemSucceeds()
+        [Fact(DisplayName = nameof(PublishExistingItemSucceeds))]
+        public virtual async Task PublishExistingItemSucceeds()
         {
             // Arrange
             var (senderQueue, receiverQueue) = CreateStream();

--- a/src/Take.Elephant/IPartitionedStream.cs
+++ b/src/Take.Elephant/IPartitionedStream.cs
@@ -29,9 +29,8 @@ namespace Take.Elephant
         /// <summary>
         /// Consume an item of the stream.
         /// </summary>
-        /// <param name="key"></param>
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        Task<(TKey key, TEvent item)> ConsumeAsync(TKey key, CancellationToken cancellationToken);
+        Task<(TKey key, TEvent item)> ConsumeOrDefaultAsync(CancellationToken cancellationToken);
     }
 }

--- a/src/Take.Elephant/IPartitionedStream.cs
+++ b/src/Take.Elephant/IPartitionedStream.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace Take.Elephant
+{
+    /// <summary>
+    /// Defines a stream storage container.
+    /// </summary>
+    /// <typeparam name="TKey"></typeparam>
+    /// <typeparam name="TEvent"></typeparam>
+    public interface IPartitionedStream<TKey, TEvent> : IEventStreamPublisher<TKey, TEvent>, IEventStreamConsumer<TKey, TEvent>
+    {
+        //discutir essa implementação amanhã / tirar duvidas
+    }
+    public interface IEventStreamPublisher<TKey, TEvent>
+    {
+        /// <summary>
+        /// Publish an item in the stream.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="item"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task PublishAsync(TKey key, TEvent item, CancellationToken cancellationToken);
+    }
+
+    public interface IEventStreamConsumer<TKey, TEvent>
+    {
+        /// <summary>
+        /// Consume an item of the stream.
+        /// </summary>
+        /// <param name="key"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task<(TKey key, TEvent item)> ConsumeAsync(TKey key, CancellationToken cancellationToken);
+    }
+}

--- a/src/Take.Elephant/IQueue.cs
+++ b/src/Take.Elephant/IQueue.cs
@@ -59,5 +59,5 @@ namespace Take.Elephant
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         Task<IEnumerable<T>> DequeueBatchAsync(int maxBatchSize, CancellationToken cancellationToken);
-    }
+    }    
 }

--- a/src/Take.Elephant/Memory/PartitionedStream.cs
+++ b/src/Take.Elephant/Memory/PartitionedStream.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Concurrent;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -45,14 +46,17 @@ namespace Take.Elephant.Memory
                 return TaskUtil.CompletedTask;
             }
         }
-        public async Task<(TKey key, TEvent item)> ConsumeAsync(TKey key, CancellationToken cancellationToken)
+        public async Task<(TKey key, TEvent item)> ConsumeOrDefaultAsync(CancellationToken cancellationToken)
         {
+            (TKey, TEvent) result;
             lock (_syncRoot)
             {
-                return _dictionary.TryRemove(key, out var result)
-                    ? (key, result)
-                    : (default(TKey), default(TEvent));
+                var key = _dictionary.FirstOrDefault().Key;
+                result = _dictionary.TryRemove(key, out var eventResult)
+                   ? (key, eventResult)
+                   : (default(TKey), default(TEvent));
             }
+            return await Task.FromResult(result);
         }
     }
 }

--- a/src/Take.Elephant/Memory/PartitionedStream.cs
+++ b/src/Take.Elephant/Memory/PartitionedStream.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Take.Elephant.Memory
+{
+    /// <summary>
+    /// Implements the <see cref="IPartitionedStream{TKey, TEvent}"/> interface using the <see cref="ConcurrentDictionary{TKey, TValue}"/> class.
+    /// </summary>
+    /// <typeparam name="TKey"></typeparam>
+    /// <typeparam name="TEvent"></typeparam>
+    public class PartitionedStream<TKey, TEvent> : IPartitionedStream<TKey, TEvent>
+    {
+        private readonly ConcurrentDictionary<TKey, TEvent> _dictionary;
+        private readonly ConcurrentQueue<Tuple<TaskCompletionSource<TEvent>, CancellationTokenRegistration>> _promisesQueue;
+        private readonly object _syncRoot = new object();
+
+        public PartitionedStream()
+        {
+            _dictionary = new ConcurrentDictionary<TKey, TEvent>();
+            _promisesQueue = new ConcurrentQueue<Tuple<TaskCompletionSource<TEvent>, CancellationTokenRegistration>>();
+        }
+
+        public Task PublishAsync(TKey key, TEvent item, CancellationToken cancellationToken)
+        {
+            if (item == null)
+                throw new ArgumentNullException(nameof(item));
+            lock (_syncRoot)
+            {
+                Tuple<TaskCompletionSource<TEvent>, CancellationTokenRegistration> promise;
+                do
+                {
+                    if (_promisesQueue.TryDequeue(out promise) &&
+                        !promise.Item1.Task.IsCanceled &&
+                        promise.Item1.TrySetResult(item))
+                    {
+                        promise.Item2.Dispose();
+                        return TaskUtil.CompletedTask;
+                    }
+                }
+                while (promise != null);
+
+                _dictionary.GetOrAdd(key, item);
+                return TaskUtil.CompletedTask;
+            }
+        }
+        public async Task<(TKey key, TEvent item)> ConsumeAsync(TKey key, CancellationToken cancellationToken)
+        {
+            lock (_syncRoot)
+            {
+                return _dictionary.TryRemove(key, out var result)
+                    ? (key, result)
+                    : (default(TKey), default(TEvent));
+            }
+        }
+    }
+}


### PR DESCRIPTION
Implementations for a new consumer and producer for a Kafka Partitioned Stream. This implementation was necessary for adding the message ID as the Key of the message.
Those new classes were made to avoid changing the way that the queue works today. 

We made a test to validate the behavior of the stream with messages containing a key, the results are in the image below:
<img width="196" alt="Screenshot_1" src="https://user-images.githubusercontent.com/85257810/134416776-7381ce04-7371-45a1-b526-df818835b0d6.png">


