### PR TITLE
Adding new constructor to KafkaSenderQueue 

### DIFF
--- a/src/Take.Elephant.Kafka/KafkaSenderQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaSenderQueue.cs
@@ -46,7 +46,7 @@ namespace Take.Elephant.Kafka
             string topic)
         {
             _serializer = serializer;
-             Topic = topic;
+            Topic = topic;
             _producer = new KafkaEventStreamPublisher<Null, string>(producer, topic);
         }
 


### PR DESCRIPTION
Adding a new constructor, that receives an IProducer as a parameter, to maintain KafkaSenderQueue class compatibility.