### PR TITLE
Change the empty set indicator on redis impl to use hash slots

### DIFF
--- a/src/Take.Elephant.Redis/RedisSet.cs
+++ b/src/Take.Elephant.Redis/RedisSet.cs
@@ -132,7 +132,7 @@ namespace Take.Elephant.Redis
             return database.SetLengthAsync(Name, ReadFlags);
         }
 
-        internal static RedisKey GetEmptySetIndicatorForKey(string key) => $"{key}{EMPTY_SET_INDICATOR}";
+        internal static RedisKey GetEmptySetIndicatorForKey(string key) => $"{{{key}}}{EMPTY_SET_INDICATOR}";
 
     }
 }


### PR DESCRIPTION
Change the empty set indicator on redis impl to use hash slots so that the empty set indicator key falls onto the same slot as the main key when using Redis Cluster; When this is not the case, multi-key operations are forbidden (such as the transaction on `RedisMap<TKey, TValue>.TryAddAsync`).