### PR TITLE
Adding the possibility to send messages with partition key

### DIFF
--- a/src/Take.Elephant.Kafka/KafkaPartitionQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaPartitionQueue.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
+using Confluent.Kafka;
 
 namespace Take.Elephant.Kafka
 {
@@ -10,6 +11,18 @@ namespace Take.Elephant.Kafka
     {
         private readonly KafkaPartitionSenderQueue<T> _senderQueue;
         private readonly KafkaReceiverQueue<T> _receiverQueue;
+
+        public KafkaPartitionQueue(
+            ProducerConfig producerConfig,
+            ConsumerConfig consumerConfig,
+            string topic,
+            Take.Elephant.ISerializer<T> serializer,
+            Confluent.Kafka.ISerializer<string> kafkaSerializer = null,
+            IDeserializer<string> kafkaDeserializer = null)
+        {
+            _senderQueue = new KafkaPartitionSenderQueue<T>(producerConfig, topic, serializer, kafkaSerializer);
+            _receiverQueue = new KafkaReceiverQueue<T>(consumerConfig, topic, serializer, kafkaDeserializer);
+        }
 
         public Task EnqueueAsync(T item, string key, CancellationToken cancellationToken = default)
         {

--- a/src/Take.Elephant.Kafka/KafkaPartitionQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaPartitionQueue.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Take.Elephant.Kafka
+{
+    public class KafkaPartitionQueue<T> : IReceiverQueue<T>, IPartitionSenderQueue<T>, ICloseable, IDisposable
+    {
+        private readonly KafkaPartitionSenderQueue<T> _senderQueue;
+        private readonly KafkaReceiverQueue<T> _receiverQueue;
+
+        public Task EnqueueAsync(T item, string key, CancellationToken cancellationToken = default)
+        {
+            return _senderQueue.EnqueueAsync(item, key, cancellationToken);
+        }
+
+        public Task<T> DequeueOrDefaultAsync(CancellationToken cancellationToken = default)
+        {
+            return _receiverQueue.DequeueOrDefaultAsync(cancellationToken);
+        }
+
+        public Task<T> DequeueAsync(CancellationToken cancellationToken = default)
+        {
+            return _receiverQueue.DequeueAsync(cancellationToken);
+        }
+
+        public Task CloseAsync(CancellationToken cancellationToken) => _receiverQueue.CloseAsync(cancellationToken);
+
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _senderQueue?.Dispose();
+                _receiverQueue?.Dispose();
+            }
+        }
+    }
+}

--- a/src/Take.Elephant.Kafka/KafkaPartitionSenderQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaPartitionSenderQueue.cs
@@ -11,22 +11,20 @@ namespace Take.Elephant.Kafka
         private readonly ISerializer<T> _serializer;
 
         public KafkaPartitionSenderQueue(string bootstrapServers, string topic, ISerializer<T> serializer)
-        : this(new ProducerConfig() { BootstrapServers = bootstrapServers }, topic, serializer)
-        {
-        }
+        : this(new ProducerConfig() { BootstrapServers = bootstrapServers }, topic, serializer) { }
 
         public KafkaPartitionSenderQueue(
             string bootstrapServers,
             string topic,
             ISerializer<T> serializer,
             Confluent.Kafka.ISerializer<string> kafkaSerializer)
-            : this(new ProducerConfig() { BootstrapServers = bootstrapServers }, topic, serializer, kafkaSerializer) { }
+        : this(new ProducerConfig() { BootstrapServers = bootstrapServers }, topic, serializer, kafkaSerializer) { }
 
         public KafkaPartitionSenderQueue(
             ProducerConfig producerConfig,
             string topic,
             ISerializer<T> serializer)
-            : this(producerConfig, topic, serializer, null) { }
+        : this(producerConfig, topic, serializer, null) { }
 
         public KafkaPartitionSenderQueue(
             ProducerConfig producerConfig,

--- a/src/Take.Elephant.Kafka/KafkaPartitionSenderQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaPartitionSenderQueue.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+
+namespace Take.Elephant.Kafka
+{
+    public class KafkaPartitionSenderQueue<T> : IPartitionSenderQueue<T>, IDisposable
+    {
+        private readonly IEventStreamPublisher<string, string> _producer;
+        private readonly ISerializer<T> _serializer;
+
+        public KafkaPartitionSenderQueue(string bootstrapServers, string topic, ISerializer<T> serializer)
+        : this(new ProducerConfig() { BootstrapServers = bootstrapServers }, topic, serializer)
+        {
+        }
+
+        public KafkaPartitionSenderQueue(
+            string bootstrapServers,
+            string topic,
+            ISerializer<T> serializer,
+            Confluent.Kafka.ISerializer<string> kafkaSerializer)
+            : this(new ProducerConfig() { BootstrapServers = bootstrapServers }, topic, serializer, kafkaSerializer) { }
+
+        public KafkaPartitionSenderQueue(
+            ProducerConfig producerConfig,
+            string topic,
+            ISerializer<T> serializer)
+            : this(producerConfig, topic, serializer, null) { }
+
+        public KafkaPartitionSenderQueue(
+            ProducerConfig producerConfig,
+            string topic,
+            ISerializer<T> serializer,
+            Confluent.Kafka.ISerializer<string> kafkaSerializer)
+        {
+            Topic = topic;
+            _serializer = serializer;
+            _producer = new KafkaEventStreamPublisher<string, string>(producerConfig, topic, kafkaSerializer ?? new StringSerializer());
+        }
+
+        public KafkaPartitionSenderQueue(
+            IProducer<string, string> producer,
+            ISerializer<T> serializer,
+            string topic)
+        {
+            Topic = topic;
+            _serializer = serializer;
+            _producer = new KafkaEventStreamPublisher<string, string>(producer, topic);
+        }
+
+        public string Topic { get; }
+
+        public virtual Task EnqueueAsync(T item, string key, CancellationToken cancellationToken = default)
+        {
+            var stringItem = _serializer.Serialize(item);
+            return _producer.PublishAsync(key, stringItem, cancellationToken);
+        }
+
+        public void Dispose() => (_producer as IDisposable)?.Dispose();
+    }
+}

--- a/src/Take.Elephant/IQueue.cs
+++ b/src/Take.Elephant/IQueue.cs
@@ -39,6 +39,18 @@ namespace Take.Elephant
         Task EnqueueAsync(T item, CancellationToken cancellationToken = default);
     }
 
+    public interface IPartitionSenderQueue<T>
+    {
+        /// <summary>
+        /// Enqueues an item, mapping it into specific partitions according to the provided <paramref name="key"/>.
+        /// </summary>
+        /// <param name="item"></param>
+        /// <param name="key"></param>
+        /// <param name="cancellationToken"></param>
+        /// <returns></returns>
+        Task EnqueueAsync(T item, string key, CancellationToken cancellationToken = default);
+    }
+
     public interface IBatchSenderQueue<T>
     {
         /// <summary>
@@ -59,5 +71,5 @@ namespace Take.Elephant
         /// <param name="cancellationToken"></param>
         /// <returns></returns>
         Task<IEnumerable<T>> DequeueBatchAsync(int maxBatchSize, CancellationToken cancellationToken);
-    }    
+    }
 }


### PR DESCRIPTION
> The partition key is a sender-supplied value passed into an event hub. It is processed through a static hashing function, which creates the partition assignment. 
> Without a partition key, a round-robin assignment is used when publishing an event.

* Now you can use a partition key to map incoming event data into specific partitions for the purpose of data organization. 
* Do not need any huge change at your client code, just inherit your queue class from KafkaPartitionQueue.
* Tests and monitoring made with Azure Event Hub Explorer. Please refer to [this PR](https://github.com/SummerSun/vscode-azure-event-hub-explorer/pull/33)