### PR TITLE
Allow full-async enumerator on IAsyncEnumerable for Sql implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -207,3 +207,6 @@ FakesAssemblies/
 **/.idea/**/*.iml
 **/.idea/**/contentModel.xml
 **/.idea/**/modules.xml
+
+# CodeRush
+.cr/

--- a/src/Take.Elephant.Samples/Map/SqlDataMap.cs
+++ b/src/Take.Elephant.Samples/Map/SqlDataMap.cs
@@ -21,7 +21,7 @@ namespace Take.Elephant.Samples.Map
             : base(@"Server=(localdb)\MSSQLLocalDB;Database=Elephant;Integrated Security=true",
                 table, new ValueMapper<Guid>("Id"), new TypeMapper<Data>(table))
         {
-               
+            UseFullyAsyncEnumerator = true;
         }
     }
 }

--- a/src/Take.Elephant.Samples/Set/SqlDataSet.cs
+++ b/src/Take.Elephant.Samples/Set/SqlDataSet.cs
@@ -18,6 +18,7 @@ namespace Take.Elephant.Samples.Set
         public SqlDataSet() 
             : base(@"Server=(localdb)\MSSQLLocalDB;Database=Elephant;Integrated Security=true", table, new TypeMapper<Data>(table))
         {
+            UseFullyAsyncEnumerator = true;
         }
 
     }

--- a/src/Take.Elephant.Samples/SetMap/SqlDataSetMap.cs
+++ b/src/Take.Elephant.Samples/SetMap/SqlDataSetMap.cs
@@ -21,6 +21,7 @@ namespace Take.Elephant.Samples.SetMap
             : base(@"Server=(localdb)\MSSQLLocalDB;Database=Elephant;Integrated Security=true",
                 table, new ValueMapper<Guid>("Id"), new TypeMapper<Data>(table))
         {
+            UseFullyAsyncEnumerator = true;
         }
     }
 }

--- a/src/Take.Elephant.Samples/Take.Elephant.Samples.csproj
+++ b/src/Take.Elephant.Samples/Take.Elephant.Samples.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFrameworks>netcoreapp3.1;net6.0</TargetFrameworks>
+    <TargetFrameworks>net6.0</TargetFrameworks>
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/src/Take.Elephant.Sql/DbDataReaderAsyncEnumerator2.cs
+++ b/src/Take.Elephant.Sql/DbDataReaderAsyncEnumerator2.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Data.Common;
+using System.Threading;
+using System.Threading.Tasks;
+using Take.Elephant.Sql.Mapping;
+
+namespace Take.Elephant.Sql
+{
+    public class DbDataReaderAsyncEnumerator2<T> : IAsyncEnumerator<T>
+    {
+        private readonly Func<CancellationToken, Task<DbConnection>> _dbConnectionFactory;
+        private readonly Func<DbConnection, DbCommand> _dbCommandFactory;
+        private readonly IMapper<T> _mapper;
+        private readonly string[] _selectColumns;
+        private readonly CancellationToken _cancellationToken;
+
+        private DbCommand _dbCommand;
+        private DbDataReader _sqlDataReader;
+
+        public DbDataReaderAsyncEnumerator2(
+            Func<CancellationToken, Task<DbConnection>> dbConnectionFactory,
+            Func<DbConnection, DbCommand> dbCommandFactory,
+            IMapper<T> mapper,
+            string[] selectColumns, 
+            CancellationToken cancellationToken)
+        {
+            _dbConnectionFactory = dbConnectionFactory;
+            _dbCommandFactory = dbCommandFactory;
+            _mapper = mapper;
+            _selectColumns = selectColumns;
+            _cancellationToken = cancellationToken;
+        }
+
+        public T Current => _mapper.Create(_sqlDataReader, _selectColumns);
+
+        public async ValueTask<bool> MoveNextAsync()
+        {
+            if (_sqlDataReader == null)
+            {
+                var dbConnection = await _dbConnectionFactory(_cancellationToken).ConfigureAwait(false);
+                if (dbConnection.State == ConnectionState.Closed)
+                    await dbConnection.OpenAsync(_cancellationToken).ConfigureAwait(false);
+                _dbCommand = _dbCommandFactory(dbConnection);
+                _sqlDataReader = await _dbCommand.ExecuteReaderAsync(_cancellationToken).ConfigureAwait(false);
+            }
+
+            return await _sqlDataReader.ReadAsync(_cancellationToken);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            if (_sqlDataReader != null)
+            {
+                await _sqlDataReader.DisposeAsync().ConfigureAwait(false);
+            }
+
+            if (_dbCommand != null)
+            {
+                await _dbCommand.DisposeAsync().ConfigureAwait(false);
+            }
+
+        }
+    }
+}

--- a/src/Take.Elephant.Sql/MapStorageBase.cs
+++ b/src/Take.Elephant.Sql/MapStorageBase.cs
@@ -66,7 +66,8 @@ namespace Take.Elephant.Sql
                         c =>
                             c.CreateSelectSkipTakeCommand(DatabaseDriver, Table, selectColumns, filter.Where, skip, take, orderByColumns, filterValues: filter.FilterValues),
                         new KeyValuePairMapper<TKey, TValue>(KeyMapper, Mapper),
-                        selectColumns),
+                        selectColumns,
+                        UseFullyAsyncEnumerator),
                     totalCount);
             }
         }
@@ -112,7 +113,8 @@ namespace Take.Elephant.Sql
                             selectColumns,
                             filterValues: filter.FilterValues),
                         KeyMapper, 
-                        selectColumns),
+                        selectColumns,
+                        UseFullyAsyncEnumerator),
                     totalCount);
             }
         }

--- a/src/Take.Elephant.Sql/SqlCollectionBase.cs
+++ b/src/Take.Elephant.Sql/SqlCollectionBase.cs
@@ -23,7 +23,8 @@ namespace Take.Elephant.Sql
                 GetConnectionAsync,
                 c => c.CreateSelectCommand(DatabaseDriver, Table, null, selectColumns),
                 Mapper,
-                selectColumns);
+                selectColumns,
+                UseFullyAsyncEnumerator);
         }
 
         public virtual async Task<long> GetLengthAsync(CancellationToken cancellationToken = default)

--- a/src/Take.Elephant.Sql/SqlMap.cs
+++ b/src/Take.Elephant.Sql/SqlMap.cs
@@ -60,11 +60,12 @@ namespace Take.Elephant.Sql
                     var selectColumns = Table.Columns.Keys.ToArray();
 
                     return await new DbDataReaderAsyncEnumerable<TValue>(
-                        // ReSharper disable once AccessToDisposedClosure
-                        t => connection.AsCompletedTask(),
-                        c => c.CreateSelectCommand(DatabaseDriver, Table, keyColumnValues, selectColumns),
-                        Mapper,
-                        selectColumns)
+                            // ReSharper disable once AccessToDisposedClosure
+                            t => connection.AsCompletedTask(),
+                            c => c.CreateSelectCommand(DatabaseDriver, Table, keyColumnValues, selectColumns),
+                            Mapper,
+                            selectColumns,
+                            UseFullyAsyncEnumerator)
                         .FirstOrDefaultAsync(cancellationTokenSource.Token)
                         .ConfigureAwait(false);
                 }
@@ -97,7 +98,12 @@ namespace Take.Elephant.Sql
         {
             var selectColumns = Table.KeyColumnsNames;
             return Task.FromResult<IAsyncEnumerable<TKey>>(
-                new DbDataReaderAsyncEnumerable<TKey>(GetConnectionAsync, c => c.CreateSelectCommand(DatabaseDriver, Table, null, selectColumns), KeyMapper, selectColumns));
+                new DbDataReaderAsyncEnumerable<TKey>(
+                    GetConnectionAsync, 
+                    c => c.CreateSelectCommand(DatabaseDriver, Table, null, selectColumns), 
+                    KeyMapper, 
+                    selectColumns, 
+                    UseFullyAsyncEnumerator));
         }
 
         public virtual async Task SetPropertyValueAsync<TProperty>(TKey key, string propertyName,

--- a/src/Take.Elephant.Sql/SqlSetMap.cs
+++ b/src/Take.Elephant.Sql/SqlSetMap.cs
@@ -163,7 +163,8 @@ namespace Take.Elephant.Sql
                             GetConnectionAsync,
                             c => c.CreateSelectCommand(DatabaseDriver, Table, keyColumnValues, selectColumns),
                             Mapper,
-                            selectColumns)
+                            selectColumns,
+                            UseFullyAsyncEnumerator)
                             .FirstOrDefaultAsync(cancellationTokenSource.Token);
             }
         }
@@ -176,7 +177,8 @@ namespace Take.Elephant.Sql
                     GetConnectionAsync,
                     c => c.CreateSelectCommand(DatabaseDriver, Table, null, selectColumns),
                     KeyMapper,
-                    selectColumns));
+                    selectColumns,
+                    UseFullyAsyncEnumerator));
         }
 
         private class InternalSet : SqlSet<TItem>
@@ -209,7 +211,8 @@ namespace Take.Elephant.Sql
                     GetConnectionAsync,
                     c => c.CreateSelectCommand(DatabaseDriver, Table, MapKeyColumnValues, selectColumns),
                     Mapper,
-                    selectColumns);
+                    selectColumns,
+                    UseFullyAsyncEnumerator);
             }
 
             public override async Task<long> GetLengthAsync(CancellationToken cancellationToken = default)

--- a/src/Take.Elephant.Sql/StorageBase.cs
+++ b/src/Take.Elephant.Sql/StorageBase.cs
@@ -26,6 +26,13 @@ namespace Take.Elephant.Sql
         /// </summary>
         public bool FetchQueryResultTotal { get; set; } = true;
 
+        /// <summary>
+        /// Enable/disable returning of a (new) fully async implementation of
+        /// IAsyncEnumerable/IAsyncEnumerator.
+        /// Default: false (backward compatibility)
+        /// </summary>
+        public bool UseFullyAsyncEnumerator { get; set; } = false;
+
         protected IDatabaseDriver DatabaseDriver { get; }
 
         protected string ConnectionString { get; }
@@ -182,7 +189,8 @@ namespace Take.Elephant.Sql
                                 filterValues,
                                 distinct),
                         Mapper,
-                        selectColumns),
+                        selectColumns,
+                        UseFullyAsyncEnumerator),
                     totalCount);
             }
         }


### PR DESCRIPTION
Introduce property `UseFullyAsyncEnumerator` to enable a new `IAsyncEnumerator` implementation that is "full async", since current implementation uses `.Result` inside it.

This property is expected to be temporary. After validations (I hope) the new implementation should be the only one, and this property could be removed.