### PR TITLE
upgrading SqlClient version

### DIFF
--- a/src/Take.Elephant.Sql/Take.Elephant.Sql.csproj
+++ b/src/Take.Elephant.Sql/Take.Elephant.Sql.csproj
@@ -20,7 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
-    <PackageReference Include="System.Data.SqlClient" Version="4.5.1" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.5" />
     <PackageReference Include="System.Runtime.Serialization.Primitives" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
security issue being addressed: https://github.com/advisories/GHSA-8g2p-5pqh-5jmc

This is the last suported version for System.Data.SqlClient.
Next change will be a change of library to Microsoft.Data.SqlClient