### PR TITLE
update redis version from 2.6.96 to 2.6.111

### DIFF
--- a/src/Take.Elephant.Redis/MapBase.cs
+++ b/src/Take.Elephant.Redis/MapBase.cs
@@ -81,8 +81,7 @@ namespace Take.Elephant.Redis
                 var key = ((string) k).Substring(Name.Length + 1, value.Length - Name.Length - 1);
                 return GetKeyFromString(key);
             });
-            return Task.FromResult<IAsyncEnumerable<TKey>>(
-                new AsyncEnumerableWrapper<TKey>(keys));
+            return Task.FromResult(keys.ToAsyncEnumerable());
         }
     }
 }

--- a/src/Take.Elephant.Redis/Take.Elephant.Redis.csproj
+++ b/src/Take.Elephant.Redis/Take.Elephant.Redis.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup> 
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.6.96" />
+    <PackageReference Include="StackExchange.Redis" Version="2.6.111" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
   </ItemGroup>
 


### PR DESCRIPTION
This update was requested to improve GC and log messages:

https://github.com/StackExchange/StackExchange.Redis/pull/2408
https://github.com/StackExchange/StackExchange.Redis/pull/2452

Full release description: https://github.com/StackExchange/StackExchange.Redis/releases