### PR TITLE
Migrating to Azure.Messaging.ServiceBus from Microsoft.Azure.ServiceBus

### DIFF
--- a/src/Take.Elephant.Azure/AzureServiceBusQueue.cs
+++ b/src/Take.Elephant.Azure/AzureServiceBusQueue.cs
@@ -38,7 +38,7 @@ namespace Take.Elephant.Azure
             _receiveMode = receiveMode;
             _client = new ServiceBusClient(connectionString, new ServiceBusClientOptions
             {
-                RetryOptions = retryOptions,
+                RetryOptions = retryOptions ?? new ServiceBusRetryOptions(),
             });
             _messageSender = _client.CreateSender(entityPath);
             _messageReceiver = _client.CreateReceiver(entityPath, new ServiceBusReceiverOptions

--- a/src/Take.Elephant.Azure/Take.Elephant.Azure.csproj
+++ b/src/Take.Elephant.Azure/Take.Elephant.Azure.csproj
@@ -17,10 +17,10 @@
     <SymbolPackageFormat>snupkg</SymbolPackageFormat>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.4" />
     <PackageReference Include="Azure.Storage.Queues" Version="12.12.0" />
     <PackageReference Include="Dawn.Guard" Version="1.6.0" />
     <PackageReference Include="Microsoft.Azure.EventHubs" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Azure.ServiceBus" Version="5.2.0" />
     <PackageReference Include="System.Threading.Tasks.Dataflow" Version="4.9.0" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Take.Elephant.Tests/Azure/AzureServiceBusItemBlockingQueueFacts.cs
+++ b/src/Take.Elephant.Tests/Azure/AzureServiceBusItemBlockingQueueFacts.cs
@@ -1,5 +1,5 @@
-﻿using Microsoft.Azure.ServiceBus.Management;
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
+using Azure.Messaging.ServiceBus.Administration;
 using Take.Elephant.Azure;
 using Take.Elephant.Tests.Redis;
 using Xunit;
@@ -26,14 +26,12 @@ namespace Take.Elephant.Tests.Azure
 
         private async Task DeleteQueueAsync(string connectionString, string path)
         {
-            var managementClient = new ManagementClient(connectionString);
+            var administrationClient = new ServiceBusAdministrationClient(connectionString);
 
-            if (await managementClient.QueueExistsAsync(path))
+            if (await administrationClient.QueueExistsAsync(path))
             {
-                await managementClient.DeleteQueueAsync(path);
+                await administrationClient.DeleteQueueAsync(path);
             }
-
-            await managementClient.CloseAsync();
         }
     }
 }


### PR DESCRIPTION
The `Take.Elephant.Azure.AzureServiceBusQueue` implementation has been changed to use the `Azure.Messaging.ServiceBus` package instead of `Microsoft.Azure.ServiceBus` to support migration to .NET 8.

All changes were made based on: [Guide for migrating to Azure.Messaging.ServiceBus from Microsoft.Azure.ServiceBus](https://github.com/Azure/azure-sdk-for-net/blob/main/sdk/servicebus/Azure.Messaging.ServiceBus/MigrationGuide.md).