### PR TITLE
Update Redis version from 2.7.27 to 2.7.33

### DIFF
--- a/src/Take.Elephant.Redis/Take.Elephant.Redis.csproj
+++ b/src/Take.Elephant.Redis/Take.Elephant.Redis.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.7.27" />
+    <PackageReference Include="StackExchange.Redis" Version="2.7.33" />
     <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="8.0.1" />
     <PackageReference Include="System.Diagnostics.TraceSource" Version="4.3.0" />
   </ItemGroup>


### PR DESCRIPTION
Update Redis version to prevent thread pool hopping and blocking on awaits  Fix [#2664](https://github.com/StackExchange/StackExchange.Redis/issues/2664)
Update from [2.7.27](https://github.com/StackExchange/StackExchange.Redis/releases/tag/2.7.27) to [2.7.33](https://github.com/StackExchange/StackExchange.Redis/releases/tag/2.7.33)