### PR TITLE
feat: implement kafka headers support

### DIFF
--- a/src/Take.Elephant.Kafka/IKafkaHeaderProvider.cs
+++ b/src/Take.Elephant.Kafka/IKafkaHeaderProvider.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Confluent.Kafka;
+
+namespace Take.Elephant.Kafka
+{
+    /// <summary>
+    /// Provides Kafka message headers to be injected into every produced message.
+    /// Implementations are resolved at produce-time, so headers can be dynamic
+    /// (e.g. trace IDs) or static (e.g. deployment metadata read once at startup).
+    /// </summary>
+    public interface IKafkaHeaderProvider
+    {
+        IEnumerable<IHeader> GetHeaders();
+    }
+}

--- a/src/Take.Elephant.Kafka/IKafkaReceiverQueue.cs
+++ b/src/Take.Elephant.Kafka/IKafkaReceiverQueue.cs
@@ -1,0 +1,26 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Take.Elephant.Kafka
+{
+    /// <summary>
+    /// Optional Kafka receiver contract that allows reading message headers together with the payload.
+    /// </summary>
+    /// <typeparam name="T">Payload type.</typeparam>
+    public interface IKafkaReceiverQueue<T> : IReceiverQueue<T>, IBlockingReceiverQueue<T>
+    {
+        /// <summary>
+        /// Dequeues a payload with its Kafka headers, if available.
+        /// </summary>
+        Task<KafkaConsumedMessage<T>> DequeueWithHeadersOrDefaultAsync(
+            CancellationToken cancellationToken = default
+        );
+
+        /// <summary>
+        /// Dequeues a payload with its Kafka headers, awaiting for a message if needed.
+        /// </summary>
+        Task<KafkaConsumedMessage<T>> DequeueWithHeadersAsync(
+            CancellationToken cancellationToken
+        );
+    }
+}

--- a/src/Take.Elephant.Kafka/KafkaConsumedMessage.cs
+++ b/src/Take.Elephant.Kafka/KafkaConsumedMessage.cs
@@ -1,0 +1,49 @@
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+
+namespace Take.Elephant.Kafka
+{
+    internal static class KafkaConsumedMessageDefaults
+    {
+        internal static readonly IReadOnlyDictionary<string, byte[]> EmptyHeaders =
+            new ReadOnlyDictionary<string, byte[]>(new Dictionary<string, byte[]>());
+    }
+
+    /// <summary>
+    /// Represents a consumed Kafka payload with its message headers.
+    /// </summary>
+    /// <typeparam name="T">Payload type.</typeparam>
+    public sealed class KafkaConsumedMessage<T>(T item, IReadOnlyDictionary<string, byte[]> headers)
+    {
+
+        private readonly IReadOnlyDictionary<string, byte[]> _headers =
+             headers is null
+                 ? KafkaConsumedMessageDefaults.EmptyHeaders
+                 : new ReadOnlyDictionary<string, byte[]>(new Dictionary<string, byte[]>(headers));
+
+        public T Item { get; } = item;
+
+        public IReadOnlyDictionary<string, byte[]> Headers => _headers;
+
+        public bool TryGetHeader(string key, out byte[] value)
+        {
+            if (!string.IsNullOrWhiteSpace(key)) return Headers.TryGetValue(key, out value);
+            value = null;
+            return false;
+
+        }
+
+        public bool TryGetHeaderAsUtf8String(string key, out string value)
+        {
+            value = null;
+            if (!TryGetHeader(key, out var bytes) || bytes == null)
+            {
+                return false;
+            }
+
+            value = Encoding.UTF8.GetString(bytes);
+            return true;
+        }
+    }
+}

--- a/src/Take.Elephant.Kafka/KafkaConsumedMessage.cs
+++ b/src/Take.Elephant.Kafka/KafkaConsumedMessage.cs
@@ -14,21 +14,36 @@ namespace Take.Elephant.Kafka
     /// Represents a consumed Kafka payload with its message headers.
     /// </summary>
     /// <typeparam name="T">Payload type.</typeparam>
-    public sealed class KafkaConsumedMessage<T>(T item, IReadOnlyDictionary<string, byte[]> headers)
+    public sealed class KafkaConsumedMessage<T>
     {
+        public KafkaConsumedMessage(T item, IReadOnlyDictionary<string, byte[]> headers)
+            : this(item, headers, headersAreSafe: false)
+        {
+        }
+
+        internal KafkaConsumedMessage(T item, IReadOnlyDictionary<string, byte[]> headers, bool headersAreSafe)
+        {
+            Item = item;
+            _headers = headersAreSafe
+                ? UseProvidedHeaders(headers)
+                : CreateReadOnlyHeaders(headers);
+        }
 
         private readonly IReadOnlyDictionary<string, byte[]> _headers =
-             headers is null
-                 ? KafkaConsumedMessageDefaults.EmptyHeaders
-                 : new ReadOnlyDictionary<string, byte[]>(new Dictionary<string, byte[]>(headers));
+            KafkaConsumedMessageDefaults.EmptyHeaders;
 
-        public T Item { get; } = item;
+        public T Item { get; }
 
         public IReadOnlyDictionary<string, byte[]> Headers => _headers;
 
         public bool TryGetHeader(string key, out byte[] value)
         {
-            if (!string.IsNullOrWhiteSpace(key)) return Headers.TryGetValue(key, out value);
+            if (!string.IsNullOrWhiteSpace(key) && Headers.TryGetValue(key, out var headerValue))
+            {
+                value = headerValue != null ? (byte[])headerValue.Clone() : null;
+                return true;
+            }
+
             value = null;
             return false;
 
@@ -44,6 +59,34 @@ namespace Take.Elephant.Kafka
 
             value = Encoding.UTF8.GetString(bytes);
             return true;
+        }
+
+        private static IReadOnlyDictionary<string, byte[]> CreateReadOnlyHeaders(
+            IReadOnlyDictionary<string, byte[]> headers)
+        {
+            if (headers is null || headers.Count == 0)
+            {
+                return KafkaConsumedMessageDefaults.EmptyHeaders;
+            }
+
+            var result = new Dictionary<string, byte[]>(headers.Count);
+            foreach (var header in headers)
+            {
+                result[header.Key] = header.Value != null ? (byte[])header.Value.Clone() : null;
+            }
+
+            return new ReadOnlyDictionary<string, byte[]>(result);
+        }
+
+        private static IReadOnlyDictionary<string, byte[]> UseProvidedHeaders(
+            IReadOnlyDictionary<string, byte[]> headers)
+        {
+            if (headers is null || headers.Count == 0)
+            {
+                return KafkaConsumedMessageDefaults.EmptyHeaders;
+            }
+
+            return headers;
         }
     }
 }

--- a/src/Take.Elephant.Kafka/KafkaEventStreamPublisher.cs
+++ b/src/Take.Elephant.Kafka/KafkaEventStreamPublisher.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -26,9 +27,7 @@ namespace Take.Elephant.Kafka
             string topic,
             ISerializer<TEvent> serializer)
             : this(
-                  new ProducerBuilder<TKey, TEvent>(producerConfig)
-                        .SetValueSerializer(new EventSerializer(serializer))
-                        .Build(),
+                CreateProducer(producerConfig, serializer),
                   topic,
                   null)
         {
@@ -40,9 +39,7 @@ namespace Take.Elephant.Kafka
             ISerializer<TEvent> serializer,
             IKafkaHeaderProvider headerProvider)
             : this(
-                  new ProducerBuilder<TKey, TEvent>(producerConfig)
-                        .SetValueSerializer(new EventSerializer(serializer))
-                        .Build(),
+                CreateProducer(producerConfig, serializer),
                   topic,
                   headerProvider)
         {
@@ -53,9 +50,7 @@ namespace Take.Elephant.Kafka
             string topic,
             Confluent.Kafka.ISerializer<TEvent> kafkaSerializer)
             : this(
-                  new ProducerBuilder<TKey, TEvent>(producerConfig)
-                        .SetValueSerializer(kafkaSerializer)
-                        .Build(),
+                CreateProducer(producerConfig, kafkaSerializer),
                   topic,
                   null)
         {
@@ -67,9 +62,7 @@ namespace Take.Elephant.Kafka
             Confluent.Kafka.ISerializer<TEvent> kafkaSerializer,
             IKafkaHeaderProvider headerProvider)
             : this(
-                  new ProducerBuilder<TKey, TEvent>(producerConfig)
-                        .SetValueSerializer(kafkaSerializer)
-                        .Build(),
+                CreateProducer(producerConfig, kafkaSerializer),
                   topic,
                   headerProvider)
         {
@@ -126,18 +119,16 @@ namespace Take.Elephant.Kafka
 
             if (_headerProvider != null)
             {
-                message.Headers = [];
-                var headers = _headerProvider.GetHeaders();
-                 if (headers != null)
+                var headers = _headerProvider.GetHeaders() ?? Array.Empty<IHeader>();
+                foreach (var header in headers)
                 {
-                    foreach (var header in headers)
-                     {
-                         if (header == null || header.Key == null)
-                         {
-                             continue;
-                         }
-                         message.Headers.Add(header.Key, header.GetValueBytes());
-                     }
+                    if (header == null || header.Key == null)
+                    {
+                        continue;
+                    }
+
+                    message.Headers ??= new Headers();
+                    message.Headers.Add(header.Key, header.GetValueBytes());
                 }
             }
 
@@ -158,11 +149,43 @@ namespace Take.Elephant.Kafka
             GC.SuppressFinalize(this);
         }
 
-        public class EventSerializer(ISerializer<TEvent> serializer) : Confluent.Kafka.ISerializer<TEvent>
+        private static IProducer<TKey, TEvent> CreateProducer(
+            ProducerConfig producerConfig,
+            ISerializer<TEvent> serializer)
         {
+            ArgumentNullException.ThrowIfNull(producerConfig);
+            ArgumentNullException.ThrowIfNull(serializer);
+
+            return new ProducerBuilder<TKey, TEvent>(producerConfig)
+                .SetValueSerializer(new EventSerializer(serializer))
+                .Build();
+        }
+
+        private static IProducer<TKey, TEvent> CreateProducer(
+            ProducerConfig producerConfig,
+            Confluent.Kafka.ISerializer<TEvent> kafkaSerializer)
+        {
+            ArgumentNullException.ThrowIfNull(producerConfig);
+            ArgumentNullException.ThrowIfNull(kafkaSerializer);
+
+            return new ProducerBuilder<TKey, TEvent>(producerConfig)
+                .SetValueSerializer(kafkaSerializer)
+                .Build();
+        }
+
+        public class EventSerializer : Confluent.Kafka.ISerializer<TEvent>
+        {
+            private readonly ISerializer<TEvent> _serializer;
+
+            public EventSerializer(ISerializer<TEvent> serializer)
+            {
+                ArgumentNullException.ThrowIfNull(serializer);
+                _serializer = serializer;
+            }
+
             public byte[] Serialize(TEvent data, SerializationContext context)
             {
-                return Encoding.UTF8.GetBytes(serializer.Serialize(data));
+                return Encoding.UTF8.GetBytes(_serializer.Serialize(data));
             }
         }
     }

--- a/src/Take.Elephant.Kafka/KafkaEventStreamPublisher.cs
+++ b/src/Take.Elephant.Kafka/KafkaEventStreamPublisher.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -9,6 +9,7 @@ namespace Take.Elephant.Kafka
     public class KafkaEventStreamPublisher<TKey, TEvent> : IEventStreamPublisher<TKey, TEvent>, IDisposable
     {
         private readonly IProducer<TKey, TEvent> _producer;
+        private readonly IKafkaHeaderProvider _headerProvider;
 
         public KafkaEventStreamPublisher(string bootstrapServers, string topic, ISerializer<TEvent> serializer)
             : this(new ProducerConfig() { BootstrapServers = bootstrapServers }, topic, serializer)
@@ -21,14 +22,29 @@ namespace Take.Elephant.Kafka
         }
 
         public KafkaEventStreamPublisher(
-            ProducerConfig producerConfig,            
+            ProducerConfig producerConfig,
             string topic,
             ISerializer<TEvent> serializer)
             : this(
                   new ProducerBuilder<TKey, TEvent>(producerConfig)
                         .SetValueSerializer(new EventSerializer(serializer))
                         .Build(),
-                  topic)
+                  topic,
+                  null)
+        {
+        }
+
+        public KafkaEventStreamPublisher(
+            ProducerConfig producerConfig,
+            string topic,
+            ISerializer<TEvent> serializer,
+            IKafkaHeaderProvider headerProvider)
+            : this(
+                  new ProducerBuilder<TKey, TEvent>(producerConfig)
+                        .SetValueSerializer(new EventSerializer(serializer))
+                        .Build(),
+                  topic,
+                  headerProvider)
         {
         }
 
@@ -40,7 +56,22 @@ namespace Take.Elephant.Kafka
                   new ProducerBuilder<TKey, TEvent>(producerConfig)
                         .SetValueSerializer(kafkaSerializer)
                         .Build(),
-                  topic)
+                  topic,
+                  null)
+        {
+        }
+
+        public KafkaEventStreamPublisher(
+            ProducerConfig producerConfig,
+            string topic,
+            Confluent.Kafka.ISerializer<TEvent> kafkaSerializer,
+            IKafkaHeaderProvider headerProvider)
+            : this(
+                  new ProducerBuilder<TKey, TEvent>(producerConfig)
+                        .SetValueSerializer(kafkaSerializer)
+                        .Build(),
+                  topic,
+                  headerProvider)
         {
         }
 
@@ -53,22 +84,64 @@ namespace Take.Elephant.Kafka
                 throw new ArgumentException("Value cannot be null or whitespace.", nameof(topic));
             }
 
+            if (producer == null)
+             {
+                 throw new ArgumentNullException(nameof(producer));
+             }
+
             _producer = producer;
             Topic = topic;
+            _headerProvider = null;
+        }
+
+        public KafkaEventStreamPublisher(
+            IProducer<TKey, TEvent> producer,
+            string topic,
+            IKafkaHeaderProvider headerProvider)
+        {
+            if (string.IsNullOrWhiteSpace(topic))
+            {
+                throw new ArgumentException("Value cannot be null or whitespace.", nameof(topic));
+            }
+
+            if (producer == null)
+             {
+                 throw new ArgumentNullException(nameof(producer));
+             }
+
+            _producer = producer;
+            Topic = topic;
+            _headerProvider = headerProvider;
         }
 
         public string Topic { get; }
 
         public async Task PublishAsync(TKey key, TEvent item, CancellationToken cancellationToken)
         {
-            await _producer.ProduceAsync(
-                Topic,
-                new Message<TKey, TEvent>
+            var message = new Message<TKey, TEvent>
+            {
+                Key = key,
+                Value = item
+            };
+
+            if (_headerProvider != null)
+            {
+                message.Headers = [];
+                var headers = _headerProvider.GetHeaders();
+                 if (headers != null)
                 {
-                    Key = key,
-                    Value = item
-                },
-                cancellationToken);
+                    foreach (var header in headers)
+                     {
+                         if (header == null || header.Key == null)
+                         {
+                             continue;
+                         }
+                         message.Headers.Add(header.Key, header.GetValueBytes());
+                     }
+                }
+            }
+
+            await _producer.ProduceAsync(Topic, message, cancellationToken);
         }
 
         protected virtual void Dispose(bool disposing)
@@ -85,17 +158,11 @@ namespace Take.Elephant.Kafka
             GC.SuppressFinalize(this);
         }
 
-        public class EventSerializer : Confluent.Kafka.ISerializer<TEvent>
+        public class EventSerializer(ISerializer<TEvent> serializer) : Confluent.Kafka.ISerializer<TEvent>
         {
-            private readonly ISerializer<TEvent> _serializer;
-
-            public EventSerializer(ISerializer<TEvent> serializer)
-            {
-                _serializer = serializer;
-            }
             public byte[] Serialize(TEvent data, SerializationContext context)
             {
-                return Encoding.UTF8.GetBytes(_serializer.Serialize(data));
+                return Encoding.UTF8.GetBytes(serializer.Serialize(data));
             }
         }
     }

--- a/src/Take.Elephant.Kafka/KafkaHeadersConverter.cs
+++ b/src/Take.Elephant.Kafka/KafkaHeadersConverter.cs
@@ -1,0 +1,35 @@
+using System.Collections.Generic;
+using Confluent.Kafka;
+
+namespace Take.Elephant.Kafka
+{
+    internal static class KafkaHeadersConverter
+    {
+        internal static KafkaConsumedMessage<T> BuildConsumedMessage<T>(T item, Headers headers)
+        {
+            return new KafkaConsumedMessage<T>(item, ToDictionary(headers));
+        }
+
+        internal static Dictionary<string, byte[]> ToDictionary(Headers headers)
+        {
+            if (headers == null || headers.Count == 0)
+            {
+                return null;
+            }
+
+            var result = new Dictionary<string, byte[]>(headers.Count);
+            foreach (var header in headers)
+            {
+                if (header?.Key == null)
+                {
+                    continue;
+                }
+
+                var valueBytes = header.GetValueBytes();
+                result[header.Key] = valueBytes != null ? (byte[])valueBytes.Clone() : null;
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/Take.Elephant.Kafka/KafkaHeadersConverter.cs
+++ b/src/Take.Elephant.Kafka/KafkaHeadersConverter.cs
@@ -1,4 +1,5 @@
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Confluent.Kafka;
 
 namespace Take.Elephant.Kafka
@@ -7,14 +8,14 @@ namespace Take.Elephant.Kafka
     {
         internal static KafkaConsumedMessage<T> BuildConsumedMessage<T>(T item, Headers headers)
         {
-            return new KafkaConsumedMessage<T>(item, ToDictionary(headers));
+            return new KafkaConsumedMessage<T>(item, ToDictionary(headers), headersAreSafe: true);
         }
 
-        internal static Dictionary<string, byte[]> ToDictionary(Headers headers)
+        internal static IReadOnlyDictionary<string, byte[]> ToDictionary(Headers headers)
         {
             if (headers == null || headers.Count == 0)
             {
-                return null;
+                return KafkaConsumedMessageDefaults.EmptyHeaders;
             }
 
             var result = new Dictionary<string, byte[]>(headers.Count);
@@ -29,7 +30,12 @@ namespace Take.Elephant.Kafka
                 result[header.Key] = valueBytes != null ? (byte[])valueBytes.Clone() : null;
             }
 
-            return result;
+            if (result.Count == 0)
+            {
+                return KafkaConsumedMessageDefaults.EmptyHeaders;
+            }
+
+            return new ReadOnlyDictionary<string, byte[]>(result);
         }
     }
 }

--- a/src/Take.Elephant.Kafka/KafkaPartitionQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaPartitionQueue.cs
@@ -1,13 +1,11 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 using Confluent.Kafka;
 
 namespace Take.Elephant.Kafka
 {
-    public class KafkaPartitionQueue<T> : IReceiverQueue<T>, IPartitionSenderQueue<T>, ICloseable, IDisposable
+    public class KafkaPartitionQueue<T> : IKafkaReceiverQueue<T>, IPartitionSenderQueue<T>, ICloseable, IDisposable
     {
         private readonly KafkaPartitionSenderQueue<T> _senderQueue;
         private readonly KafkaReceiverQueue<T> _receiverQueue;
@@ -16,12 +14,13 @@ namespace Take.Elephant.Kafka
             ProducerConfig producerConfig,
             ConsumerConfig consumerConfig,
             string topic,
-            Take.Elephant.ISerializer<T> serializer,
+            ISerializer<T> serializer,
             Confluent.Kafka.ISerializer<string> kafkaSerializer = null,
-            IDeserializer<string> kafkaDeserializer = null)
+            IDeserializer<string> kafkaDeserializer = null,
+            IKafkaHeaderProvider headerProvider = null)
         {
-            _senderQueue = new KafkaPartitionSenderQueue<T>(producerConfig, topic, serializer, kafkaSerializer);
-            _receiverQueue = new KafkaReceiverQueue<T>(consumerConfig, topic, serializer, kafkaDeserializer);
+            _senderQueue = new(producerConfig, topic, serializer, kafkaSerializer, headerProvider);
+            _receiverQueue = new(consumerConfig, topic, serializer, kafkaDeserializer);
         }
 
         public Task EnqueueAsync(T item, string key, CancellationToken cancellationToken = default)
@@ -34,9 +33,23 @@ namespace Take.Elephant.Kafka
             return _receiverQueue.DequeueOrDefaultAsync(cancellationToken);
         }
 
-        public Task<T> DequeueAsync(CancellationToken cancellationToken = default)
+        public Task<KafkaConsumedMessage<T>> DequeueWithHeadersOrDefaultAsync(
+            CancellationToken cancellationToken = default
+        )
+        {
+            return _receiverQueue.DequeueWithHeadersOrDefaultAsync(cancellationToken);
+        }
+
+        public Task<T> DequeueAsync(CancellationToken cancellationToken)
         {
             return _receiverQueue.DequeueAsync(cancellationToken);
+        }
+
+        public Task<KafkaConsumedMessage<T>> DequeueWithHeadersAsync(
+            CancellationToken cancellationToken
+        )
+        {
+            return _receiverQueue.DequeueWithHeadersAsync(cancellationToken);
         }
 
         public Task CloseAsync(CancellationToken cancellationToken) => _receiverQueue.CloseAsync(cancellationToken);
@@ -47,13 +60,11 @@ namespace Take.Elephant.Kafka
             GC.SuppressFinalize(this);
         }
 
-        protected void Dispose(bool disposing)
+        protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                _senderQueue?.Dispose();
-                _receiverQueue?.Dispose();
-            }
+            if (!disposing) return;
+            _senderQueue?.Dispose();
+            _receiverQueue?.Dispose();
         }
     }
 }

--- a/src/Take.Elephant.Kafka/KafkaPartitionQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaPartitionQueue.cs
@@ -40,7 +40,7 @@ namespace Take.Elephant.Kafka
             return _receiverQueue.DequeueWithHeadersOrDefaultAsync(cancellationToken);
         }
 
-        public Task<T> DequeueAsync(CancellationToken cancellationToken)
+        public Task<T> DequeueAsync(CancellationToken cancellationToken = default)
         {
             return _receiverQueue.DequeueAsync(cancellationToken);
         }

--- a/src/Take.Elephant.Kafka/KafkaPartitionSenderQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaPartitionSenderQueue.cs
@@ -24,17 +24,26 @@ namespace Take.Elephant.Kafka
             ProducerConfig producerConfig,
             string topic,
             ISerializer<T> serializer)
-        : this(producerConfig, topic, serializer, null) { }
+        : this(producerConfig, topic, serializer, null, null) { }
 
         public KafkaPartitionSenderQueue(
             ProducerConfig producerConfig,
             string topic,
             ISerializer<T> serializer,
             Confluent.Kafka.ISerializer<string> kafkaSerializer)
+        : this(producerConfig, topic, serializer, kafkaSerializer, null) { }
+
+        public KafkaPartitionSenderQueue(
+            ProducerConfig producerConfig,
+            string topic,
+            ISerializer<T> serializer,
+            Confluent.Kafka.ISerializer<string> kafkaSerializer,
+            IKafkaHeaderProvider headerProvider)
         {
+            ArgumentNullException.ThrowIfNull(serializer);
             Topic = topic;
             _serializer = serializer;
-            _producer = new KafkaEventStreamPublisher<string, string>(producerConfig, topic, kafkaSerializer ?? new StringSerializer());
+            _producer = new KafkaEventStreamPublisher<string, string>(producerConfig, topic, kafkaSerializer ?? new StringSerializer(), headerProvider);
         }
 
         public KafkaPartitionSenderQueue(
@@ -42,9 +51,22 @@ namespace Take.Elephant.Kafka
             ISerializer<T> serializer,
             string topic)
         {
+            ArgumentNullException.ThrowIfNull(serializer);
             Topic = topic;
             _serializer = serializer;
-            _producer = new KafkaEventStreamPublisher<string, string>(producer, topic);
+            _producer = new KafkaEventStreamPublisher<string, string>(producer, topic, null);
+        }
+
+        public KafkaPartitionSenderQueue(
+            IProducer<string, string> producer,
+            ISerializer<T> serializer,
+            string topic,
+            IKafkaHeaderProvider headerProvider)
+        {
+            ArgumentNullException.ThrowIfNull(serializer);
+            Topic = topic;
+            _serializer = serializer;
+            _producer = new KafkaEventStreamPublisher<string, string>(producer, topic, headerProvider);
         }
 
         public string Topic { get; }
@@ -55,6 +77,16 @@ namespace Take.Elephant.Kafka
             return _producer.PublishAsync(key, stringItem, cancellationToken);
         }
 
-        public void Dispose() => (_producer as IDisposable)?.Dispose();
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing) return;
+            (_producer as IDisposable)?.Dispose();
+        }
     }
 }

--- a/src/Take.Elephant.Kafka/KafkaReceiverQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaReceiverQueue.cs
@@ -1,6 +1,7 @@
 using Confluent.Kafka;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -9,13 +10,13 @@ using System.Threading.Tasks;
 
 namespace Take.Elephant.Kafka
 {
-    public class KafkaReceiverQueue<T> : IReceiverQueue<T>, IBlockingReceiverQueue<T>, IOpenable, ICloseable, IDisposable
+    public class KafkaReceiverQueue<T> : IKafkaReceiverQueue<T>, IOpenable, ICloseable, IDisposable
     {
         private readonly IConsumer<Ignore, string> _consumer;
         private readonly ISerializer<T> _serializer;
         private readonly SemaphoreSlim _consumerStartSemaphore;
         private readonly CancellationTokenSource _cts;
-        private readonly Channel<T> _channel;
+        private readonly Channel<(T Item, Headers KafkaHeaders)> _channel;
         private Task _consumerTask;
         private bool _closed;
 
@@ -42,11 +43,12 @@ namespace Take.Elephant.Kafka
         {
             if (string.IsNullOrWhiteSpace(topic)) throw new ArgumentException("Value cannot be null or whitespace.", nameof(topic));
             _consumer = consumer ?? throw new ArgumentNullException(nameof(consumer));
+            ArgumentNullException.ThrowIfNull(serializer);
             _serializer = serializer;
             Topic = topic;
             _consumerStartSemaphore = new SemaphoreSlim(1, 1);
             _cts = new CancellationTokenSource();
-            _channel = Channel.CreateBounded<T>(1);
+            _channel = Channel.CreateBounded<(T, Headers)>(1);
         }
 
         public string Topic { get; }
@@ -56,7 +58,18 @@ namespace Take.Elephant.Kafka
             await StartConsumerTaskIfNotAsync(cancellationToken);
             if (_channel.Reader.TryRead(out var item))
             {
-                return item;
+                return item.Item;
+            }
+
+            return default;
+        }
+
+        public async Task<KafkaConsumedMessage<T>> DequeueWithHeadersOrDefaultAsync(CancellationToken cancellationToken = default)
+        {
+            await StartConsumerTaskIfNotAsync(cancellationToken);
+            if (_channel.Reader.TryRead(out var item))
+            {
+                return KafkaHeadersConverter.BuildConsumedMessage(item.Item, item.KafkaHeaders);
             }
 
             return default;
@@ -65,7 +78,15 @@ namespace Take.Elephant.Kafka
         public virtual async Task<T> DequeueAsync(CancellationToken cancellationToken)
         {
             await StartConsumerTaskIfNotAsync(cancellationToken);
-            return await _channel.Reader.ReadAsync(cancellationToken);
+            var item = await _channel.Reader.ReadAsync(cancellationToken);
+            return item.Item;
+        }
+
+        public async Task<KafkaConsumedMessage<T>> DequeueWithHeadersAsync(CancellationToken cancellationToken)
+        {
+            await StartConsumerTaskIfNotAsync(cancellationToken);
+            var item = await _channel.Reader.ReadAsync(cancellationToken);
+            return KafkaHeadersConverter.BuildConsumedMessage(item.Item, item.KafkaHeaders);
         }
 
         public Task OpenAsync(CancellationToken cancellationToken)
@@ -79,7 +100,10 @@ namespace Take.Elephant.Kafka
             {
                 _closed = true;
                 await _cts.CancelAsync();
-                await _consumerTask;
+                if (_consumerTask != null)
+                {
+                    await _consumerTask;
+                }
                 _consumer.Close();
             }
         }
@@ -88,16 +112,21 @@ namespace Take.Elephant.Kafka
 
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
+            if (!disposing) return;
+            if (!_closed)
             {
-                if (!_closed)
+                _closed = true;
+                _cts.Cancel();
+                if (_consumerTask != null)
                 {
-                    _consumer.Close();
+                    _consumerTask.GetAwaiter().GetResult();
                 }
-
-                _consumer.Dispose();
-                _cts.Dispose();
+                _consumer.Close();
             }
+
+            _consumer.Dispose();
+            _cts.Dispose();
+            _consumerStartSemaphore.Dispose();
         }
 
         private async Task StartConsumerTaskIfNotAsync(CancellationToken cancellationToken)
@@ -107,15 +136,12 @@ namespace Take.Elephant.Kafka
             await _consumerStartSemaphore.WaitAsync(cancellationToken);
             try
             {
-                if (_consumerTask == null)
-                {
-                    _consumerTask = Task
-                        .Factory
-                        .StartNew(
-                            () => ConsumeAsync(_cts.Token),
-                            TaskCreationOptions.LongRunning)
-                        .Unwrap();
-                }
+                _consumerTask ??= Task
+                    .Factory
+                    .StartNew(
+                        () => ConsumeAsync(_cts.Token),
+                        TaskCreationOptions.LongRunning)
+                    .Unwrap();
             }
             finally
             {
@@ -135,8 +161,8 @@ namespace Take.Elephant.Kafka
                 try
                 {
                     var result = _consumer.Consume(cancellationToken);
-                    var resultValue = _serializer.Deserialize(result.Value);
-                    await _channel.Writer.WriteAsync(resultValue, cancellationToken);
+                    var resultValue = _serializer.Deserialize(result.Message.Value);
+                    await _channel.Writer.WriteAsync((resultValue, result.Message.Headers), cancellationToken);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {

--- a/src/Take.Elephant.Kafka/KafkaSenderQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaSenderQueue.cs
@@ -1,5 +1,4 @@
 ﻿using Confluent.Kafka;
-using Newtonsoft.Json;
 using System;
 using System.Threading;
 using System.Threading.Tasks;
@@ -25,7 +24,7 @@ namespace Take.Elephant.Kafka
             ProducerConfig producerConfig,
             string topic,
             ISerializer<T> serializer)
-            : this(producerConfig, topic, serializer, null)
+            : this(producerConfig, topic, serializer, null, null)
         {
         }
 
@@ -34,10 +33,21 @@ namespace Take.Elephant.Kafka
             string topic,
             ISerializer<T> serializer,
             Confluent.Kafka.ISerializer<string> kafkaSerializer)
+            : this(producerConfig, topic, serializer, kafkaSerializer, null)
         {
-            Topic = topic;
-            _serializer = serializer;
-            _producer = new KafkaEventStreamPublisher<Null, string>(producerConfig, topic, kafkaSerializer ?? new StringSerializer());
+        }
+
+        public KafkaSenderQueue(
+            ProducerConfig producerConfig,
+            string topic,
+            ISerializer<T> serializer,
+            Confluent.Kafka.ISerializer<string> kafkaSerializer,
+            IKafkaHeaderProvider headerProvider)
+        {
+            if (producerConfig == null) throw new ArgumentNullException(nameof(producerConfig));
+            Topic = topic ?? throw new ArgumentNullException(nameof(topic));
+            _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+            _producer = new KafkaEventStreamPublisher<Null, string>(producerConfig, topic, kafkaSerializer ?? new StringSerializer(), headerProvider);
         }
 
         public KafkaSenderQueue(
@@ -45,9 +55,30 @@ namespace Take.Elephant.Kafka
             ISerializer<T> serializer,
             string topic)
         {
-            _serializer = serializer;
-            Topic = topic;
-            _producer = new KafkaEventStreamPublisher<Null, string>(producer, topic);
+            _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+            Topic = topic ?? throw new ArgumentNullException(nameof(topic));
+            _producer = new KafkaEventStreamPublisher<Null, string>(producer ?? throw new ArgumentNullException(nameof(producer)), topic, null);
+        }
+
+        public KafkaSenderQueue(
+            IProducer<Null, string> producer,
+            ISerializer<T> serializer,
+            string topic,
+            IKafkaHeaderProvider headerProvider)
+        {
+            _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+            Topic = topic ?? throw new ArgumentNullException(nameof(topic));
+            _producer = new KafkaEventStreamPublisher<Null, string>(producer ?? throw new ArgumentNullException(nameof(producer)), topic, headerProvider);
+        }
+
+        public KafkaSenderQueue(
+            IEventStreamPublisher<Null, string> producer,
+            ISerializer<T> serializer,
+            string topic)
+        {
+            _producer = producer ?? throw new ArgumentNullException(nameof(producer));
+            _serializer = serializer ?? throw new ArgumentNullException(nameof(serializer));
+            Topic = topic ?? throw new ArgumentNullException(nameof(topic));
         }
 
         public string Topic { get; }
@@ -58,7 +89,17 @@ namespace Take.Elephant.Kafka
             return _producer.PublishAsync(null, stringItem, cancellationToken);
         }
 
-        public void Dispose() => (_producer as IDisposable)?.Dispose();
+        public void Dispose()
+        {
+            Dispose(true);
+            GC.SuppressFinalize(this);
+        }
+
+        protected virtual void Dispose(bool disposing)
+        {
+            if (!disposing) return;
+            (_producer as IDisposable)?.Dispose();
+        }
     }
 
     public class StringSerializer : Confluent.Kafka.ISerializer<string>

--- a/src/Take.Elephant.Kafka/SchemaRegistry/KafkaSchemaRegistryPartitionQueue.cs
+++ b/src/Take.Elephant.Kafka/SchemaRegistry/KafkaSchemaRegistryPartitionQueue.cs
@@ -10,7 +10,7 @@ namespace Take.Elephant.Kafka.SchemaRegistry
     /// A Kafka partition queue (partition sender and receiver) that uses Schema Registry for serialization/deserialization.
     /// </summary>
     /// <typeparam name="T">The type of items in the queue.</typeparam>
-    public class KafkaSchemaRegistryPartitionQueue<T> : IReceiverQueue<T>, IBlockingReceiverQueue<T>, IPartitionSenderQueue<T>, IOpenable, ICloseable, IDisposable where T : class
+    public class KafkaSchemaRegistryPartitionQueue<T> : IKafkaReceiverQueue<T>, IPartitionSenderQueue<T>, IOpenable, ICloseable, IDisposable where T : class
     {
         private readonly KafkaSchemaRegistryPartitionSenderQueue<T> _senderQueue;
         private readonly KafkaSchemaRegistryReceiverQueue<T> _receiverQueue;
@@ -110,10 +110,24 @@ namespace Take.Elephant.Kafka.SchemaRegistry
             return _receiverQueue.DequeueOrDefaultAsync(cancellationToken);
         }
 
+        public Task<KafkaConsumedMessage<T>> DequeueWithHeadersOrDefaultAsync(
+            CancellationToken cancellationToken = default
+        )
+        {
+            return _receiverQueue.DequeueWithHeadersOrDefaultAsync(cancellationToken);
+        }
+
         /// <inheritdoc />
         public Task<T> DequeueAsync(CancellationToken cancellationToken = default)
         {
             return _receiverQueue.DequeueAsync(cancellationToken);
+        }
+
+        public Task<KafkaConsumedMessage<T>> DequeueWithHeadersAsync(
+            CancellationToken cancellationToken
+        )
+        {
+            return _receiverQueue.DequeueWithHeadersAsync(cancellationToken);
         }
 
         /// <inheritdoc />
@@ -134,13 +148,10 @@ namespace Take.Elephant.Kafka.SchemaRegistry
 
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
-            {
-                _senderQueue?.Dispose();
-                _receiverQueue?.Dispose();
-                _sharedSchemaRegistryClient?.Dispose();
-            }
+            if (!disposing) return;
+            _senderQueue?.Dispose();
+            _receiverQueue?.Dispose();
+            _sharedSchemaRegistryClient?.Dispose();
         }
     }
 }
-

--- a/src/Take.Elephant.Kafka/SchemaRegistry/KafkaSchemaRegistryReceiverQueue.cs
+++ b/src/Take.Elephant.Kafka/SchemaRegistry/KafkaSchemaRegistryReceiverQueue.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using System.Threading;
@@ -13,14 +14,14 @@ namespace Take.Elephant.Kafka.SchemaRegistry
     /// A Kafka receiver queue that uses Schema Registry for deserialization.
     /// </summary>
     /// <typeparam name="T">The type of items in the queue.</typeparam>
-    public class KafkaSchemaRegistryReceiverQueue<T> : IReceiverQueue<T>, IBlockingReceiverQueue<T>, IOpenable, ICloseable, IDisposable where T : class
+    public class KafkaSchemaRegistryReceiverQueue<T> : IKafkaReceiverQueue<T>, IOpenable, ICloseable, IDisposable where T : class
     {
         private readonly IConsumer<Ignore, T> _consumer;
         private readonly ISchemaRegistryClient _schemaRegistryClient;
         private readonly bool _ownsSchemaRegistryClient;
         private readonly SemaphoreSlim _consumerStartSemaphore;
         private readonly CancellationTokenSource _cts;
-        private readonly Channel<T> _channel;
+        private readonly Channel<(T Item, Headers KafkaHeaders)> _channel;
         private Task _consumerTask;
         private bool _closed;
 
@@ -99,7 +100,7 @@ namespace Take.Elephant.Kafka.SchemaRegistry
 
             _consumerStartSemaphore = new SemaphoreSlim(1, 1);
             _cts = new CancellationTokenSource();
-            _channel = Channel.CreateBounded<T>(1);
+            _channel = Channel.CreateBounded<(T, Headers)>(1);
         }
 
         /// <summary>
@@ -122,7 +123,7 @@ namespace Take.Elephant.Kafka.SchemaRegistry
             _ownsSchemaRegistryClient = false;
             _consumerStartSemaphore = new SemaphoreSlim(1, 1);
             _cts = new CancellationTokenSource();
-            _channel = Channel.CreateBounded<T>(1);
+            _channel = Channel.CreateBounded<(T, Headers)>(1);
         }
 
         /// <summary>
@@ -141,17 +142,40 @@ namespace Take.Elephant.Kafka.SchemaRegistry
             await StartConsumerTaskIfNotAsync(cancellationToken);
             if (_channel.Reader.TryRead(out var item))
             {
-                return item;
+                return item.Item;
             }
 
-            return default;
+            return null;
+        }
+
+        public async Task<KafkaConsumedMessage<T>> DequeueWithHeadersOrDefaultAsync(
+            CancellationToken cancellationToken = default
+        )
+        {
+            await StartConsumerTaskIfNotAsync(cancellationToken);
+            if (_channel.Reader.TryRead(out var item))
+            {
+                return KafkaHeadersConverter.BuildConsumedMessage(item.Item, item.KafkaHeaders);
+            }
+
+            return null;
         }
 
         /// <inheritdoc />
         public virtual async Task<T> DequeueAsync(CancellationToken cancellationToken)
         {
             await StartConsumerTaskIfNotAsync(cancellationToken);
-            return await _channel.Reader.ReadAsync(cancellationToken);
+            var item = await _channel.Reader.ReadAsync(cancellationToken);
+            return item.Item;
+        }
+
+        public async Task<KafkaConsumedMessage<T>> DequeueWithHeadersAsync(
+            CancellationToken cancellationToken
+        )
+        {
+            await StartConsumerTaskIfNotAsync(cancellationToken);
+            var item = await _channel.Reader.ReadAsync(cancellationToken);
+            return KafkaHeadersConverter.BuildConsumedMessage(item.Item, item.KafkaHeaders);
         }
 
         /// <inheritdoc />
@@ -184,21 +208,25 @@ namespace Take.Elephant.Kafka.SchemaRegistry
 
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
+            if (!disposing) return;
+            if (!_closed)
             {
-                if (!_closed)
+                _closed = true;
+                _cts.Cancel();
+                if (_consumerTask != null)
                 {
-                    _consumer.Close();
+                    _consumerTask.GetAwaiter().GetResult();
                 }
+                _consumer.Close();
+            }
 
-                _consumer.Dispose();
-                _cts.Dispose();
-                _consumerStartSemaphore.Dispose();
+            _consumer.Dispose();
+            _cts.Dispose();
+            _consumerStartSemaphore.Dispose();
 
-                if (_ownsSchemaRegistryClient)
-                {
-                    _schemaRegistryClient?.Dispose();
-                }
+            if (_ownsSchemaRegistryClient)
+            {
+                _schemaRegistryClient?.Dispose();
             }
         }
 
@@ -209,15 +237,12 @@ namespace Take.Elephant.Kafka.SchemaRegistry
             await _consumerStartSemaphore.WaitAsync(cancellationToken);
             try
             {
-                if (_consumerTask == null)
-                {
-                    _consumerTask = Task
-                        .Factory
-                        .StartNew(
-                            () => ConsumeAsync(_cts.Token),
-                            TaskCreationOptions.LongRunning)
-                        .Unwrap();
-                }
+                _consumerTask ??= Task
+                    .Factory
+                    .StartNew(
+                        () => ConsumeAsync(_cts.Token),
+                        TaskCreationOptions.LongRunning)
+                    .Unwrap();
             }
             finally
             {
@@ -237,7 +262,7 @@ namespace Take.Elephant.Kafka.SchemaRegistry
                 try
                 {
                     var result = _consumer.Consume(cancellationToken);
-                    await _channel.Writer.WriteAsync(result.Message.Value, cancellationToken);
+                    await _channel.Writer.WriteAsync((result.Message.Value, result.Message.Headers), cancellationToken);
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
@@ -262,4 +287,3 @@ namespace Take.Elephant.Kafka.SchemaRegistry
         }
     }
 }
-

--- a/src/Take.Elephant.Kafka/SchemaRegistry/KafkaSchemaRegistrySenderQueue.cs
+++ b/src/Take.Elephant.Kafka/SchemaRegistry/KafkaSchemaRegistrySenderQueue.cs
@@ -91,7 +91,7 @@ namespace Take.Elephant.Kafka.SchemaRegistry
             : this(
                 producerConfig,
                 topic,
-                new CachedSchemaRegistryClient(schemaRegistryOptions.SchemaRegistryConfig),
+                new CachedSchemaRegistryClient((schemaRegistryOptions ?? throw new ArgumentNullException(nameof(schemaRegistryOptions))).SchemaRegistryConfig),
                 schemaRegistryOptions,
                 ownsSchemaRegistryClient: true,
                 headerProvider: headerProvider)
@@ -241,15 +241,16 @@ namespace Take.Elephant.Kafka.SchemaRegistry
 
             if (_headerProvider != null)
             {
-                var headers = _headerProvider.GetHeaders();
-                message.Headers = [];
-                if (headers != null)
+                var headers = _headerProvider.GetHeaders() ?? Array.Empty<IHeader>();
+                foreach (var header in headers)
                 {
-                     foreach (var header in headers)
-                     {
-                         if (header == null || header.Key == null) continue;
-                         message.Headers.Add(header.Key, header.GetValueBytes());
-                     }
+                    if (header == null || header.Key == null)
+                    {
+                        continue;
+                    }
+
+                    message.Headers ??= new Headers();
+                    message.Headers.Add(header.Key, header.GetValueBytes());
                 }
             }
 

--- a/src/Take.Elephant.Kafka/SchemaRegistry/KafkaSchemaRegistrySenderQueue.cs
+++ b/src/Take.Elephant.Kafka/SchemaRegistry/KafkaSchemaRegistrySenderQueue.cs
@@ -12,9 +12,11 @@ namespace Take.Elephant.Kafka.SchemaRegistry
     /// <typeparam name="T">The type of items in the queue.</typeparam>
     public class KafkaSchemaRegistrySenderQueue<T> : ISenderQueue<T>, IDisposable where T : class
     {
+        private const string TopicNullOrWhitespaceMessage = "Value cannot be null or whitespace.";
         private readonly IProducer<Null, T> _producer;
         private readonly ISchemaRegistryClient _schemaRegistryClient;
         private readonly bool _ownsSchemaRegistryClient;
+        private readonly IKafkaHeaderProvider _headerProvider;
 
         /// <summary>
         /// Creates a new instance of <see cref="KafkaSchemaRegistrySenderQueue{T}"/>.
@@ -33,6 +35,26 @@ namespace Take.Elephant.Kafka.SchemaRegistry
         /// <summary>
         /// Creates a new instance of <see cref="KafkaSchemaRegistrySenderQueue{T}"/>.
         /// </summary>
+        /// <param name="bootstrapServers">The Kafka bootstrap servers.</param>
+        /// <param name="topic">The topic name.</param>
+        /// <param name="schemaRegistryOptions">The Schema Registry options.</param>
+        /// <param name="headerProvider">
+         /// An optional provider used to generate Kafka message headers for each item before it is sent.
+         /// If <c>null</c>, no headers are added. Implementations may return <c>null</c> or an empty set
+         /// to indicate that no headers should be attached for a given message.
+         /// </param>
+        public KafkaSchemaRegistrySenderQueue(
+            string bootstrapServers,
+            string topic,
+            SchemaRegistryOptions schemaRegistryOptions,
+            IKafkaHeaderProvider headerProvider)
+            : this(new ProducerConfig { BootstrapServers = bootstrapServers }, topic, schemaRegistryOptions, headerProvider)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="KafkaSchemaRegistrySenderQueue{T}"/>.
+        /// </summary>
         /// <param name="producerConfig">The producer configuration.</param>
         /// <param name="topic">The topic name.</param>
         /// <param name="schemaRegistryOptions">The Schema Registry options.</param>
@@ -43,9 +65,36 @@ namespace Take.Elephant.Kafka.SchemaRegistry
             : this(
                 producerConfig,
                 topic,
+                new CachedSchemaRegistryClient((schemaRegistryOptions ?? throw new ArgumentNullException(nameof(schemaRegistryOptions))).SchemaRegistryConfig),  
+                schemaRegistryOptions,
+                ownsSchemaRegistryClient: true,
+                headerProvider: null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="KafkaSchemaRegistrySenderQueue{T}"/>.
+        /// </summary>
+        /// <param name="producerConfig">The producer configuration.</param>
+        /// <param name="topic">The topic name.</param>
+        /// <param name="schemaRegistryOptions">The Schema Registry options.</param>
+        /// <param name="headerProvider">
+         /// An optional provider used to generate Kafka message headers for each item before it is sent.
+         /// If <c>null</c>, no headers are added. Implementations may return <c>null</c> or an empty set
+         /// to indicate that no headers should be attached for a given message.
+         /// </param>
+        public KafkaSchemaRegistrySenderQueue(
+            ProducerConfig producerConfig,
+            string topic,
+            SchemaRegistryOptions schemaRegistryOptions,
+            IKafkaHeaderProvider headerProvider)
+            : this(
+                producerConfig,
+                topic,
                 new CachedSchemaRegistryClient(schemaRegistryOptions.SchemaRegistryConfig),
                 schemaRegistryOptions,
-                ownsSchemaRegistryClient: true)
+                ownsSchemaRegistryClient: true,
+                headerProvider: headerProvider)
         {
         }
 
@@ -61,7 +110,29 @@ namespace Take.Elephant.Kafka.SchemaRegistry
             string topic,
             ISchemaRegistryClient schemaRegistryClient,
             SchemaRegistryOptions schemaRegistryOptions)
-            : this(producerConfig, topic, schemaRegistryClient, schemaRegistryOptions, ownsSchemaRegistryClient: false)
+            : this(producerConfig, topic, schemaRegistryClient, schemaRegistryOptions, ownsSchemaRegistryClient: false, headerProvider: null)
+        {
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="KafkaSchemaRegistrySenderQueue{T}"/>.
+        /// </summary>
+        /// <param name="producerConfig">The producer configuration.</param>
+        /// <param name="topic">The topic name.</param>
+        /// <param name="schemaRegistryClient">The Schema Registry client.</param>
+        /// <param name="schemaRegistryOptions">The Schema Registry options.</param>
+        /// <param name="headerProvider">
+         /// An optional provider used to generate Kafka message headers for each item before it is sent.
+         /// If <c>null</c>, no headers are added. Implementations may return <c>null</c> or an empty set
+         /// to indicate that no headers should be attached for a given message.
+         /// </param>
+        public KafkaSchemaRegistrySenderQueue(
+            ProducerConfig producerConfig,
+            string topic,
+            ISchemaRegistryClient schemaRegistryClient,
+            SchemaRegistryOptions schemaRegistryOptions,
+            IKafkaHeaderProvider headerProvider)
+            : this(producerConfig, topic, schemaRegistryClient, schemaRegistryOptions, ownsSchemaRegistryClient: false, headerProvider: headerProvider)
         {
         }
 
@@ -70,14 +141,16 @@ namespace Take.Elephant.Kafka.SchemaRegistry
             string topic,
             ISchemaRegistryClient schemaRegistryClient,
             SchemaRegistryOptions schemaRegistryOptions,
-            bool ownsSchemaRegistryClient)
+            bool ownsSchemaRegistryClient,
+            IKafkaHeaderProvider headerProvider = null)
         {
             if (string.IsNullOrWhiteSpace(topic))
-                throw new ArgumentException("Value cannot be null or whitespace.", nameof(topic));
+                throw new ArgumentException(TopicNullOrWhitespaceMessage, nameof(topic));
 
             Topic = topic;
             _schemaRegistryClient = schemaRegistryClient ?? throw new ArgumentNullException(nameof(schemaRegistryClient));
             _ownsSchemaRegistryClient = ownsSchemaRegistryClient;
+            _headerProvider = headerProvider;
 
             var serializer = SchemaRegistrySerializerFactory.CreateSerializer<T>(schemaRegistryClient, schemaRegistryOptions);
             _producer = new ProducerBuilder<Null, T>(producerConfig)
@@ -90,19 +163,66 @@ namespace Take.Elephant.Kafka.SchemaRegistry
         /// </summary>
         /// <param name="producer">The Kafka producer.</param>
         /// <param name="topic">The topic name.</param>
+        public KafkaSchemaRegistrySenderQueue(
+            IProducer<Null, T> producer,
+            string topic)
+        {
+            if (string.IsNullOrWhiteSpace(topic))
+                throw new ArgumentException(TopicNullOrWhitespaceMessage, nameof(topic));
+
+            _producer = producer ?? throw new ArgumentNullException(nameof(producer));
+            Topic = topic;
+            _schemaRegistryClient = null;
+            _ownsSchemaRegistryClient = false;
+            _headerProvider = null;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="KafkaSchemaRegistrySenderQueue{T}"/> using a pre-built producer.
+        /// </summary>
+        /// <param name="producer">The Kafka producer.</param>
+        /// <param name="topic">The topic name.</param>
         /// <param name="schemaRegistryClient">The Schema Registry client (optional, for lifecycle management).</param>
         public KafkaSchemaRegistrySenderQueue(
             IProducer<Null, T> producer,
             string topic,
-            ISchemaRegistryClient schemaRegistryClient = null)
+            ISchemaRegistryClient schemaRegistryClient)
         {
             if (string.IsNullOrWhiteSpace(topic))
-                throw new ArgumentException("Value cannot be null or whitespace.", nameof(topic));
+                throw new ArgumentException(TopicNullOrWhitespaceMessage, nameof(topic));
 
             _producer = producer ?? throw new ArgumentNullException(nameof(producer));
             Topic = topic;
             _schemaRegistryClient = schemaRegistryClient;
             _ownsSchemaRegistryClient = false;
+            _headerProvider = null;
+        }
+
+        /// <summary>
+        /// Creates a new instance of <see cref="KafkaSchemaRegistrySenderQueue{T}"/> using a pre-built producer.
+        /// </summary>
+        /// <param name="producer">The Kafka producer.</param>
+        /// <param name="topic">The topic name.</param>
+        /// <param name="schemaRegistryClient">The Schema Registry client (optional, for lifecycle management).</param>
+        /// <param name="headerProvider">
+         /// An optional provider used to generate Kafka message headers for each item before it is sent.
+         /// If <c>null</c>, no headers are added. Implementations may return <c>null</c> or an empty set
+         /// to indicate that no headers should be attached for a given message.
+         /// </param>
+        public KafkaSchemaRegistrySenderQueue(
+            IProducer<Null, T> producer,
+            string topic,
+            ISchemaRegistryClient schemaRegistryClient,
+            IKafkaHeaderProvider headerProvider)
+        {
+            if (string.IsNullOrWhiteSpace(topic))
+                throw new ArgumentException(TopicNullOrWhitespaceMessage, nameof(topic));
+
+            _producer = producer ?? throw new ArgumentNullException(nameof(producer));
+            Topic = topic;
+            _schemaRegistryClient = schemaRegistryClient;
+            _ownsSchemaRegistryClient = false;
+            _headerProvider = headerProvider;
         }
 
         /// <summary>
@@ -113,14 +233,27 @@ namespace Take.Elephant.Kafka.SchemaRegistry
         /// <inheritdoc />
         public virtual async Task EnqueueAsync(T item, CancellationToken cancellationToken = default)
         {
-            await _producer.ProduceAsync(
-                Topic,
-                new Message<Null, T>
+            var message = new Message<Null, T>
+            {
+                Key = null,
+                Value = item
+            };
+
+            if (_headerProvider != null)
+            {
+                var headers = _headerProvider.GetHeaders();
+                message.Headers = [];
+                if (headers != null)
                 {
-                    Key = null,
-                    Value = item
-                },
-                cancellationToken);
+                     foreach (var header in headers)
+                     {
+                         if (header == null || header.Key == null) continue;
+                         message.Headers.Add(header.Key, header.GetValueBytes());
+                     }
+                }
+            }
+
+            await _producer.ProduceAsync(Topic, message, cancellationToken);
         }
 
         /// <inheritdoc />
@@ -132,13 +265,11 @@ namespace Take.Elephant.Kafka.SchemaRegistry
 
         protected virtual void Dispose(bool disposing)
         {
-            if (disposing)
+            if (!disposing) return;
+            _producer?.Dispose();
+            if (_ownsSchemaRegistryClient)
             {
-                _producer?.Dispose();
-                if (_ownsSchemaRegistryClient)
-                {
-                    _schemaRegistryClient?.Dispose();
-                }
+                _schemaRegistryClient?.Dispose();
             }
         }
     }

--- a/src/Take.Elephant.Kafka/SchemaRegistry/SchemaRegistrySerializerFactory.cs
+++ b/src/Take.Elephant.Kafka/SchemaRegistry/SchemaRegistrySerializerFactory.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Confluent.Kafka;
 using Confluent.Kafka.SyncOverAsync;
 using Confluent.SchemaRegistry;
@@ -23,10 +22,8 @@ namespace Take.Elephant.Kafka.SchemaRegistry
             ISchemaRegistryClient schemaRegistryClient,
             SchemaRegistryOptions options) where T : class
         {
-            if (schemaRegistryClient == null)
-                throw new ArgumentNullException(nameof(schemaRegistryClient));
-            if (options == null)
-                throw new ArgumentNullException(nameof(options));
+            ArgumentNullException.ThrowIfNull(schemaRegistryClient);
+            ArgumentNullException.ThrowIfNull(options);
 
             return options.SerializerType switch
             {
@@ -47,10 +44,8 @@ namespace Take.Elephant.Kafka.SchemaRegistry
             ISchemaRegistryClient schemaRegistryClient,
             SchemaRegistryOptions options) where T : class
         {
-            if (schemaRegistryClient == null)
-                throw new ArgumentNullException(nameof(schemaRegistryClient));
-            if (options == null)
-                throw new ArgumentNullException(nameof(options));
+            ArgumentNullException.ThrowIfNull(schemaRegistryClient);
+            ArgumentNullException.ThrowIfNull(options);
 
             return options.SerializerType switch
             {

--- a/src/Take.Elephant.Kafka/Take.Elephant.Kafka.csproj
+++ b/src/Take.Elephant.Kafka/Take.Elephant.Kafka.csproj
@@ -19,6 +19,12 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleTo">
+      <_Parameter1>Take.Elephant.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Take.Elephant\Take.Elephant.csproj" />
   </ItemGroup>
 

--- a/src/Take.Elephant.Tests/Kafka/KafkaHeadersConverterFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaHeadersConverterFacts.cs
@@ -1,0 +1,83 @@
+using Confluent.Kafka;
+using Take.Elephant.Kafka;
+using Xunit;
+
+namespace Take.Elephant.Tests.Kafka
+{
+    [Trait("Category", nameof(Kafka))]
+    public class KafkaHeadersConverterFacts
+    {
+        [Fact]
+        public void ToDictionary_WithNullHeaders_ShouldReturnNull()
+        {
+            var result = KafkaHeadersConverter.ToDictionary(null);
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ToDictionary_WithEmptyHeaders_ShouldReturnNull()
+        {
+            var result = KafkaHeadersConverter.ToDictionary(new Headers());
+
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void ToDictionary_WithDuplicateKeys_ShouldKeepLastValue()
+        {
+            var headers = new Headers
+            {
+                new Header("x-origin", new byte[] { 1 }),
+                new Header("x-origin", new byte[] { 2 })
+            };
+
+            var result = KafkaHeadersConverter.ToDictionary(headers);
+
+            Assert.NotNull(result);
+            Assert.Single(result);
+            Assert.Equal(new byte[] { 2 }, result["x-origin"]);
+        }
+
+        [Fact]
+        public void ToDictionary_ShouldCloneByteArrays()
+        {
+            var sourceBytes = new byte[] { 9, 8, 7 };
+            var headers = new Headers
+            {
+                new Header("x-test", sourceBytes)
+            };
+
+            var result = KafkaHeadersConverter.ToDictionary(headers);
+
+            Assert.NotNull(result);
+            Assert.True(result.ContainsKey("x-test"));
+            Assert.NotSame(sourceBytes, result["x-test"]);
+            Assert.Equal(new byte[] { 9, 8, 7 }, result["x-test"]);
+
+            sourceBytes[0] = 1;
+            Assert.Equal(new byte[] { 9, 8, 7 }, result["x-test"]);
+        }
+
+        [Fact]
+        public void BuildConsumedMessage_ShouldPreserveItemAndHeaders()
+        {
+            var item = new Payload { Value = "ok" };
+            var headers = new Headers
+            {
+                new Header("x-origin", new byte[] { 3 })
+            };
+
+            var result = KafkaHeadersConverter.BuildConsumedMessage(item, headers);
+
+            Assert.Same(item, result.Item);
+            Assert.True(result.Headers.ContainsKey("x-origin"));
+            Assert.Equal(new byte[] { 3 }, result.Headers["x-origin"]);
+        }
+
+        private sealed class Payload
+        {
+            public string Value { get; set; }
+        }
+    }
+}

--- a/src/Take.Elephant.Tests/Kafka/KafkaHeadersConverterFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaHeadersConverterFacts.cs
@@ -1,3 +1,5 @@
+using System;
+using System.Collections.Generic;
 using Confluent.Kafka;
 using Take.Elephant.Kafka;
 using Xunit;
@@ -8,19 +10,21 @@ namespace Take.Elephant.Tests.Kafka
     public class KafkaHeadersConverterFacts
     {
         [Fact]
-        public void ToDictionary_WithNullHeaders_ShouldReturnNull()
+        public void ToDictionary_WithNullHeaders_ShouldReturnEmptyReadOnlyDictionary()
         {
             var result = KafkaHeadersConverter.ToDictionary(null);
 
-            Assert.Null(result);
+            Assert.NotNull(result);
+            Assert.Empty(result);
         }
 
         [Fact]
-        public void ToDictionary_WithEmptyHeaders_ShouldReturnNull()
+        public void ToDictionary_WithEmptyHeaders_ShouldReturnEmptyReadOnlyDictionary()
         {
             var result = KafkaHeadersConverter.ToDictionary(new Headers());
 
-            Assert.Null(result);
+            Assert.NotNull(result);
+            Assert.Empty(result);
         }
 
         [Fact]
@@ -56,6 +60,21 @@ namespace Take.Elephant.Tests.Kafka
             Assert.Equal(new byte[] { 9, 8, 7 }, result["x-test"]);
 
             sourceBytes[0] = 1;
+            Assert.Equal(new byte[] { 9, 8, 7 }, result["x-test"]);
+        }
+
+        [Fact]
+        public void ToDictionary_WithNonEmptyHeaders_ShouldReturnReadOnlyDictionary()
+        {
+            var headers = new Headers
+            {
+                new Header("x-test", new byte[] { 9, 8, 7 })
+            };
+
+            var result = KafkaHeadersConverter.ToDictionary(headers);
+            var writableResult = Assert.IsAssignableFrom<IDictionary<string, byte[]>>(result);
+
+            Assert.Throws<NotSupportedException>(() => writableResult["x-test"] = new byte[] { 1 });
             Assert.Equal(new byte[] { 9, 8, 7 }, result["x-test"]);
         }
 

--- a/src/Take.Elephant.Tests/Kafka/KafkaItemEventStreamPublisherConsumerFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaItemEventStreamPublisherConsumerFacts.cs
@@ -113,35 +113,38 @@ namespace Take.Elephant.Tests.Kafka
                 }
                 catch (DeleteTopicsException ex)
                 {
-                    if (ex.Results == null)
-                    {
-                        continue;
-                    }
-
-                    var shouldIgnore = true;
-                    foreach (var result in ex.Results)
-                    {
-                        if (result == null)
-                        {
-                            continue;
-                        }
-
-                        if (
-                            result.Error.Code != ErrorCode.UnknownTopicOrPart
-                            && result.Error.Code != ErrorCode.TopicDeletionDisabled
-                        )
-                        {
-                            shouldIgnore = false;
-                            break;
-                        }
-                    }
-
-                    if (!shouldIgnore)
+                    if (!ShouldIgnore(ex))
                     {
                         throw;
                     }
                 }
             }
+        }
+
+        private static bool ShouldIgnore(DeleteTopicsException ex)
+        {
+            if (ex.Results == null)
+            {
+                return true;
+            }
+
+            foreach (var result in ex.Results)
+            {
+                if (result == null)
+                {
+                    continue;
+                }
+
+                if (
+                    result.Error.Code != ErrorCode.UnknownTopicOrPart
+                    && result.Error.Code != ErrorCode.TopicDeletionDisabled
+                )
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/Take.Elephant.Tests/Kafka/KafkaItemEventStreamPublisherConsumerFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaItemEventStreamPublisherConsumerFacts.cs
@@ -1,6 +1,7 @@
 using Confluent.Kafka;
+using Confluent.Kafka.Admin;
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using Take.Elephant.Kafka;
 using Take.Elephant.Tests.Azure;
 using Xunit;
@@ -10,68 +11,137 @@ namespace Take.Elephant.Tests.Kafka
     [Trait("Category", nameof(Kafka))]
     public class KafkaItemEventStreamPublisherConsumerFacts : ItemEventStreamPublisherConsumerFacts
     {
-        private readonly string topic = "items";
-        private static readonly ClientConfig clientConfig = GetKafkaConfig();
-        private static readonly ConsumerConfig consumerConfig = new ConsumerConfig(clientConfig) { GroupId = "default" };
+        private const string TOPIC_PREFIX = "items";
+        private static readonly ClientConfig _clientConfig = GetKafkaConfig();
+        private readonly List<string> _createdTopics = [];
+        private KafkaEventStreamPublisher<string, Item> _senderQueue;
+        private KafkaEventStreamConsumer<string, Item> _receiverQueue;
 
 
         private static ClientConfig GetKafkaConfig()
         {
-            ClientConfig clientConfig;
-            var localKafka = true;
-
             // Local Kafka
-            if (localKafka)
-            {
-                var bootstrapServers = "localhost:9092";
+            const string bootstrapServers = "localhost:9092";
 
-                clientConfig = new ClientConfig
-                {
-                    BootstrapServers = bootstrapServers
-                };
-            }
-
-            //Azure Event Hub
-            else
+            var kafkaConfig = new ClientConfig
             {
-                var fqdn = "";
-                var connectionString = "";
-                clientConfig = new ClientConfig
-                {
-                    BootstrapServers = fqdn,
-                    SecurityProtocol = SecurityProtocol.SaslSsl,
-                    SaslMechanism = SaslMechanism.Plain,
-                    SaslUsername = "$ConnectionString",
-                    SaslPassword = connectionString,
-                };
-            }
-            return clientConfig;
+                BootstrapServers = bootstrapServers
+            };
+            
+            return kafkaConfig;
         }
 
         public override (IEventStreamPublisher<string, Item>, IEventStreamConsumer<string, Item>) CreateStream()
         {
-            var adminClient = new AdminClientBuilder(clientConfig).Build();
-            var metadata = adminClient.GetMetadata(TimeSpan.FromSeconds(5));
-            var topicMetadata = metadata.Topics.FirstOrDefault(t => t.Topic == topic);
-            if (topicMetadata != null)
+            var topic = $"{TOPIC_PREFIX}-{Guid.NewGuid():N}";
+            EnsureTopicExists(topic);
+            _createdTopics.Add(topic);
+
+            var consumerConfig = new ConsumerConfig(_clientConfig)
             {
-                var consumer = new ConsumerBuilder<Ignore, Item>(consumerConfig)
-                    .SetValueDeserializer(new JsonDeserializer<Item>())
-                    .Build();
+                GroupId = $"default-{Guid.NewGuid():N}",
+                AutoOffsetReset = AutoOffsetReset.Earliest,
+            };
 
-                foreach (var partition in topicMetadata.Partitions)
-                {
-                    var topicPartition = new TopicPartition(topic, new Partition(partition.PartitionId));
-                    var offSet = consumer.QueryWatermarkOffsets(topicPartition, TimeSpan.FromSeconds(5));
-                    consumer.Commit(new TopicPartitionOffset[] { new TopicPartitionOffset(topicPartition, offSet.High) });
-                }
-                consumer.Close();
-            }
-
-            var senderQueue = new KafkaEventStreamPublisher<string, Item>(new ProducerConfig(clientConfig), topic, new JsonItemSerializer());
+            var senderQueue = new KafkaEventStreamPublisher<string, Item>(new ProducerConfig(_clientConfig), topic, new JsonItemSerializer());
             var receiverQueue = new KafkaEventStreamConsumer<string, Item>(consumerConfig, topic, new JsonItemSerializer());
             receiverQueue.OpenAsync(CancellationToken).Wait();
+
+            _senderQueue = senderQueue;
+            _receiverQueue = receiverQueue;
+
             return (senderQueue, receiverQueue);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (!disposing)
+            {
+                return;
+            }
+
+            _senderQueue?.Dispose();
+            _receiverQueue?.Dispose();
+            DeleteCreatedTopics();
+
+            base.Dispose(disposing);
+        }
+
+        private static void EnsureTopicExists(string topic)
+        {
+            using var adminClient = new AdminClientBuilder(_clientConfig).Build();
+
+            try
+            {
+                adminClient.CreateTopicsAsync(
+                    [
+                        new TopicSpecification
+                        {
+                            Name = topic,
+                            NumPartitions = 1,
+                            ReplicationFactor = 1,
+                        }
+                    ]
+                ).GetAwaiter().GetResult();
+            }
+            catch (CreateTopicsException ex)
+            {
+                if (
+                    ex.Results is not { Count: 1 }
+                    || ex.Results[0].Error.Code != ErrorCode.TopicAlreadyExists
+                )
+                {
+                    throw;
+                }
+            }
+        }
+
+        private void DeleteCreatedTopics()
+        {
+            if (_createdTopics.Count == 0)
+            {
+                return;
+            }
+
+            using var adminClient = new AdminClientBuilder(_clientConfig).Build();
+
+            foreach (var topic in _createdTopics)
+            {
+                try
+                {
+                    adminClient.DeleteTopicsAsync([topic]).GetAwaiter().GetResult();
+                }
+                catch (DeleteTopicsException ex)
+                {
+                    if (ex.Results == null)
+                    {
+                        continue;
+                    }
+
+                    var shouldIgnore = true;
+                    foreach (var result in ex.Results)
+                    {
+                        if (result == null)
+                        {
+                            continue;
+                        }
+
+                        if (
+                            result.Error.Code != ErrorCode.UnknownTopicOrPart
+                            && result.Error.Code != ErrorCode.TopicDeletionDisabled
+                        )
+                        {
+                            shouldIgnore = false;
+                            break;
+                        }
+                    }
+
+                    if (!shouldIgnore)
+                    {
+                        throw;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Take.Elephant.Tests/Kafka/KafkaItemSenderReceiverQueueFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaItemSenderReceiverQueueFacts.cs
@@ -119,35 +119,38 @@ namespace Take.Elephant.Tests.Kafka
                 }
                 catch (DeleteTopicsException ex)
                 {
-                    if (ex.Results == null)
-                    {
-                        continue;
-                    }
-
-                    var shouldIgnore = true;
-                    foreach (var result in ex.Results)
-                    {
-                        if (result == null)
-                        {
-                            continue;
-                        }
-
-                        if (
-                            result.Error.Code != ErrorCode.UnknownTopicOrPart
-                            && result.Error.Code != ErrorCode.TopicDeletionDisabled
-                        )
-                        {
-                            shouldIgnore = false;
-                            break;
-                        }
-                    }
-
-                    if (!shouldIgnore)
+                    if (!ShouldIgnore(ex))
                     {
                         throw;
                     }
                 }
             }
+        }
+
+        private static bool ShouldIgnore(DeleteTopicsException ex)
+        {
+            if (ex.Results == null)
+            {
+                return true;
+            }
+
+            foreach (var result in ex.Results)
+            {
+                if (result == null)
+                {
+                    continue;
+                }
+
+                if (
+                    result.Error.Code != ErrorCode.UnknownTopicOrPart
+                    && result.Error.Code != ErrorCode.TopicDeletionDisabled
+                )
+                {
+                    return false;
+                }
+            }
+
+            return true;
         }
     }
 }

--- a/src/Take.Elephant.Tests/Kafka/KafkaItemSenderReceiverQueueFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaItemSenderReceiverQueueFacts.cs
@@ -1,6 +1,7 @@
 using Confluent.Kafka;
+using Confluent.Kafka.Admin;
 using System;
-using System.Linq;
+using System.Collections.Generic;
 using Take.Elephant.Kafka;
 using Take.Elephant.Tests.Azure;
 using Xunit;
@@ -10,72 +11,46 @@ namespace Take.Elephant.Tests.Kafka
     [Trait("Category", nameof(Kafka))]
     public class KafkaItemSenderReceiverQueueFacts : ItemSenderReceiverQueueFacts
     {
-        private readonly string _topic = "items";
+        private const string TOPIC_PREFIX = "items";
         private static readonly ClientConfig _clientConfig = GetKafkaConfig();
-        private static readonly ConsumerConfig _consumerConfig = new ConsumerConfig(_clientConfig) { GroupId = "default" };
+        private readonly List<string> _createdTopics = [];
         private KafkaSenderQueue<Item> _senderQueue;
         private KafkaReceiverQueue<Item> _receiverQueue;
 
         private static ClientConfig GetKafkaConfig()
         {
-            ClientConfig clientConfig;
-            var localKafka = true;
+            const string bootstrapServers = "localhost:9092";
 
-            // Local Kafka
-            if (localKafka)
+            var clientConfig = new ClientConfig
             {
-                var bootstrapServers = "localhost:9092";
-
-                clientConfig = new ClientConfig
-                {
-                    BootstrapServers = bootstrapServers
-                };
-            }
-
-            //Azure Event Hub
-            else
-            {
-                var fqdn = "";
-                var connectionString = "";
-                clientConfig = new ClientConfig
-                {
-                    BootstrapServers = fqdn,
-                    SecurityProtocol = SecurityProtocol.SaslSsl,
-                    SaslMechanism = SaslMechanism.Plain,
-                    SaslUsername = "$ConnectionString",
-                    SaslPassword = connectionString,
-                };
-            }
+                BootstrapServers = bootstrapServers
+            };
+            
             return clientConfig;
         }
 
         public override (ISenderQueue<Item>, IBlockingReceiverQueue<Item>) Create()
         {
+            var topic = $"{TOPIC_PREFIX}-{Guid.NewGuid():N}";
+            EnsureTopicExists(topic);
+            _createdTopics.Add(topic);
+
             var consumerConfig = new ConsumerConfig(_clientConfig)
             {
-                GroupId = "default"
+                GroupId = $"default-{Guid.NewGuid():N}",
+                AutoOffsetReset = AutoOffsetReset.Earliest,
             };
-
-            var adminClient = new AdminClientBuilder(_clientConfig).Build();
-            var metadata = adminClient.GetMetadata(TimeSpan.FromSeconds(5));
-            var topicMetadata = metadata.Topics.FirstOrDefault(t => t.Topic == _topic);
-            if (topicMetadata != null)
-            {
-                var consumer = new ConsumerBuilder<Ignore, Item>(consumerConfig)
-                    .SetValueDeserializer(new JsonDeserializer<Item>())
-                    .Build();
-
-                foreach (var partition in topicMetadata.Partitions)
-                {
-                    var topicPartition = new TopicPartition(_topic, new Partition(partition.PartitionId));
-                    var offSet = consumer.QueryWatermarkOffsets(topicPartition, TimeSpan.FromSeconds(5));
-                    consumer.Commit(new TopicPartitionOffset[] {new TopicPartitionOffset(topicPartition, offSet.High)});
-                }
-                consumer.Close();
-            }
             
-            var senderQueue = new KafkaSenderQueue<Item>(new ProducerConfig(_clientConfig), _topic, new JsonItemSerializer());
-            var receiverQueue = new KafkaReceiverQueue<Item>(consumerConfig, _topic, new JsonItemSerializer());
+            var senderQueue = new KafkaSenderQueue<Item>(
+                new ProducerConfig(_clientConfig),
+                topic,
+                new JsonItemSerializer()
+            );
+            var receiverQueue = new KafkaReceiverQueue<Item>(
+                consumerConfig,
+                topic,
+                new JsonItemSerializer()
+            );
             receiverQueue.OpenAsync(CancellationToken).Wait();
 
             _senderQueue = senderQueue;
@@ -86,9 +61,93 @@ namespace Take.Elephant.Tests.Kafka
 
         protected override void Dispose(bool disposing)
         {
+            if (!disposing)
+             {
+                 base.Dispose(disposing);
+                 return;
+             }
+             
             _senderQueue?.Dispose();
             _receiverQueue?.Dispose();
+            DeleteCreatedTopics();
             base.Dispose(disposing);
+        }
+
+        private static void EnsureTopicExists(string topic)
+        {
+            using var adminClient = new AdminClientBuilder(_clientConfig).Build();
+
+            try
+            {
+                adminClient.CreateTopicsAsync(
+                    [
+                        new TopicSpecification
+                        {
+                            Name = topic,
+                            NumPartitions = 1,
+                            ReplicationFactor = 1,
+                        }
+                    ]
+                ).GetAwaiter().GetResult();
+            }
+            catch (CreateTopicsException ex)
+            {
+                if (
+                    ex.Results is not { Count: 1 }
+                    || ex.Results[0].Error.Code != ErrorCode.TopicAlreadyExists
+                )
+                {
+                    throw;
+                }
+            }
+        }
+
+        private void DeleteCreatedTopics()
+        {
+            if (_createdTopics.Count == 0)
+            {
+                return;
+            }
+
+            using var adminClient = new AdminClientBuilder(_clientConfig).Build();
+
+            foreach (var topic in _createdTopics)
+            {
+                try
+                {
+                    adminClient.DeleteTopicsAsync([topic]).GetAwaiter().GetResult();
+                }
+                catch (DeleteTopicsException ex)
+                {
+                    if (ex.Results == null)
+                    {
+                        continue;
+                    }
+
+                    var shouldIgnore = true;
+                    foreach (var result in ex.Results)
+                    {
+                        if (result == null)
+                        {
+                            continue;
+                        }
+
+                        if (
+                            result.Error.Code != ErrorCode.UnknownTopicOrPart
+                            && result.Error.Code != ErrorCode.TopicDeletionDisabled
+                        )
+                        {
+                            shouldIgnore = false;
+                            break;
+                        }
+                    }
+
+                    if (!shouldIgnore)
+                    {
+                        throw;
+                    }
+                }
+            }
         }
     }
 }

--- a/src/Take.Elephant.Tests/Kafka/KafkaReceiverQueueHeadersFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaReceiverQueueHeadersFacts.cs
@@ -1,0 +1,189 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using NSubstitute;
+using Take.Elephant.Kafka;
+using Take.Elephant.Kafka.SchemaRegistry;
+using Xunit;
+
+namespace Take.Elephant.Tests.Kafka
+{
+    [Trait("Category", nameof(Kafka))]
+    public class KafkaReceiverQueueHeadersFacts
+    {
+        [Fact]
+        public async Task KafkaReceiverQueue_ShouldReturnPayloadAndHeaders()
+        {
+            // Arrange
+            var expectedItem = new TestItem { Value = "payload" };
+            var serializer = Substitute.For<ISerializer<TestItem>>();
+            serializer.Deserialize("serialized-value").Returns(expectedItem);
+
+            var consumer = Substitute.For<IConsumer<Ignore, string>>();
+            consumer.Subscription.Returns(new List<string>());
+
+            var consumeResult = new ConsumeResult<Ignore, string>
+            {
+                Message = new Message<Ignore, string>
+                {
+                    Value = "serialized-value",
+                    Headers =
+                    [
+                        new Header("x-origin", Encoding.UTF8.GetBytes("billing")),
+                        new Header("x-correlation-id", Encoding.UTF8.GetBytes("corr-123"))
+                    ]
+                }
+            };
+
+            SetupConsumeSequence(consumer, consumeResult);
+
+            var queue = new KafkaReceiverQueue<TestItem>(consumer, serializer, "topic-a");
+
+            // Act
+            var consumed = await queue.DequeueWithHeadersAsync(CancellationToken.None);
+
+            // Assert
+            Assert.Same(expectedItem, consumed.Item);
+            Assert.True(consumed.TryGetHeaderAsUtf8String("x-origin", out var origin));
+            Assert.Equal("billing", origin);
+            Assert.True(consumed.TryGetHeaderAsUtf8String("x-correlation-id", out var correlationId));
+            Assert.Equal("corr-123", correlationId);
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task KafkaSchemaRegistryReceiverQueue_ShouldReturnPayloadAndHeaders()
+        {
+            // Arrange
+            var expectedItem = new TestItem { Value = "payload" };
+            var consumer = Substitute.For<IConsumer<Ignore, TestItem>>();
+            consumer.Subscription.Returns(new List<string>());
+
+            var consumeResult = new ConsumeResult<Ignore, TestItem>
+            {
+                Message = new Message<Ignore, TestItem>
+                {
+                    Value = expectedItem,
+                    Headers =
+                    [
+                        new Header("x-origin", Encoding.UTF8.GetBytes("billing")),
+                        new Header("x-correlation-id", Encoding.UTF8.GetBytes("corr-123"))
+                    ]
+                }
+            };
+
+            SetupConsumeSequence(consumer, consumeResult);
+
+            var queue = new KafkaSchemaRegistryReceiverQueue<TestItem>(consumer, "topic-a");
+
+            // Act
+            var consumed = await queue.DequeueWithHeadersAsync(CancellationToken.None);
+
+            // Assert
+            Assert.Same(expectedItem, consumed.Item);
+            Assert.True(consumed.TryGetHeaderAsUtf8String("x-origin", out var origin));
+            Assert.Equal("billing", origin);
+            Assert.True(consumed.TryGetHeaderAsUtf8String("x-correlation-id", out var correlationId));
+            Assert.Equal("corr-123", correlationId);
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task KafkaReceiverQueue_DequeueAsync_ThenDequeueWithHeadersOrDefaultAsync_ShouldReturnNull_WhenQueueIsEmpty()
+        {
+            // Arrange
+            var expectedItem = new TestItem { Value = "payload" };
+            var serializer = Substitute.For<ISerializer<TestItem>>();
+            serializer.Deserialize("serialized-value").Returns(expectedItem);
+
+            var consumer = Substitute.For<IConsumer<Ignore, string>>();
+            consumer.Subscription.Returns(new List<string>());
+
+            var consumeResult = new ConsumeResult<Ignore, string>
+            {
+                Message = new Message<Ignore, string>
+                {
+                    Value = "serialized-value",
+                    Headers = null,
+                }
+            };
+
+            SetupConsumeSequence(consumer, consumeResult);
+
+            var queue = new KafkaReceiverQueue<TestItem>(consumer, serializer, "topic-a");
+
+            // Act
+            var item = await queue.DequeueAsync(CancellationToken.None);
+            var consumed = await queue.DequeueWithHeadersOrDefaultAsync(CancellationToken.None);
+
+            // Assert
+            Assert.Same(expectedItem, item);
+            Assert.Null(consumed);
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task KafkaSchemaRegistryReceiverQueue_DequeueWithHeadersAsync_ShouldReturnEmptyHeaders_WhenMessageHasNoHeaders()
+        {
+            // Arrange
+            var expectedItem = new TestItem { Value = "payload" };
+            var consumer = Substitute.For<IConsumer<Ignore, TestItem>>();
+            consumer.Subscription.Returns(new List<string>());
+
+            var consumeResult = new ConsumeResult<Ignore, TestItem>
+            {
+                Message = new Message<Ignore, TestItem>
+                {
+                    Value = expectedItem,
+                    Headers = null,
+                }
+            };
+
+            SetupConsumeSequence(consumer, consumeResult);
+
+            var queue = new KafkaSchemaRegistryReceiverQueue<TestItem>(consumer, "topic-a");
+
+            // Act
+            var consumed = await queue.DequeueWithHeadersAsync(CancellationToken.None);
+
+            // Assert
+            Assert.Same(expectedItem, consumed.Item);
+            Assert.Empty(consumed.Headers);
+            Assert.False(consumed.TryGetHeaderAsUtf8String("x-origin", out _));
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        private static void SetupConsumeSequence<TKey, TValue>(
+            IConsumer<TKey, TValue> consumer,
+            ConsumeResult<TKey, TValue> firstResult)
+        {
+            var calls = 0;
+            consumer
+                .Consume(Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    var cancellationToken = callInfo.Arg<CancellationToken>();
+                    calls++;
+                    if (calls == 1)
+                    {
+                        return firstResult;
+                    }
+
+                    cancellationToken.WaitHandle.WaitOne();
+                    throw new OperationCanceledException(cancellationToken);
+                });
+        }
+
+        public sealed class TestItem
+        {
+            public string Value { get; set; }
+        }
+    }
+}

--- a/src/Take.Elephant.Tests/Kafka/KafkaReceiverQueueHeadersFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaReceiverQueueHeadersFacts.cs
@@ -19,7 +19,7 @@ namespace Take.Elephant.Tests.Kafka
         {
             // Arrange
             var expectedItem = new TestItem { Value = "payload" };
-            var serializer = Substitute.For<ISerializer<TestItem>>();
+            var serializer = Substitute.For<Take.Elephant.ISerializer<TestItem>>();
             serializer.Deserialize("serialized-value").Returns(expectedItem);
 
             var consumer = Substitute.For<IConsumer<Ignore, string>>();
@@ -30,11 +30,10 @@ namespace Take.Elephant.Tests.Kafka
                 Message = new Message<Ignore, string>
                 {
                     Value = "serialized-value",
-                    Headers =
-                    [
-                        new Header("x-origin", Encoding.UTF8.GetBytes("billing")),
-                        new Header("x-correlation-id", Encoding.UTF8.GetBytes("corr-123"))
-                    ]
+                    Headers = CreateHeaders(
+                        ("x-origin", "billing"),
+                        ("x-correlation-id", "corr-123")
+                    )
                 }
             };
 
@@ -68,11 +67,10 @@ namespace Take.Elephant.Tests.Kafka
                 Message = new Message<Ignore, TestItem>
                 {
                     Value = expectedItem,
-                    Headers =
-                    [
-                        new Header("x-origin", Encoding.UTF8.GetBytes("billing")),
-                        new Header("x-correlation-id", Encoding.UTF8.GetBytes("corr-123"))
-                    ]
+                    Headers = CreateHeaders(
+                        ("x-origin", "billing"),
+                        ("x-correlation-id", "corr-123")
+                    )
                 }
             };
 
@@ -98,7 +96,7 @@ namespace Take.Elephant.Tests.Kafka
         {
             // Arrange
             var expectedItem = new TestItem { Value = "payload" };
-            var serializer = Substitute.For<ISerializer<TestItem>>();
+            var serializer = Substitute.For<Take.Elephant.ISerializer<TestItem>>();
             serializer.Deserialize("serialized-value").Returns(expectedItem);
 
             var consumer = Substitute.For<IConsumer<Ignore, string>>();
@@ -179,6 +177,17 @@ namespace Take.Elephant.Tests.Kafka
                     cancellationToken.WaitHandle.WaitOne();
                     throw new OperationCanceledException(cancellationToken);
                 });
+        }
+
+        private static Headers CreateHeaders(params (string Key, string Value)[] headers)
+        {
+            var result = new Headers();
+            foreach (var (key, value) in headers)
+            {
+                result.Add(key, Encoding.UTF8.GetBytes(value));
+            }
+
+            return result;
         }
 
         public sealed class TestItem

--- a/src/Take.Elephant.Tests/Kafka/KafkaSenderAndSchemaRegistryCoverageFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaSenderAndSchemaRegistryCoverageFacts.cs
@@ -17,7 +17,7 @@ namespace Take.Elephant.Tests.Kafka
         [Fact]
         public void KafkaSenderQueue_BootstrapCtor_ShouldCreateInstance()
         {
-            var serializer = Substitute.For<ISerializer<TestItem>>();
+            var serializer = Substitute.For<Take.Elephant.ISerializer<TestItem>>();
 
             var queue = new KafkaSenderQueue<TestItem>("localhost:9092", "topic-a", serializer);
 
@@ -28,7 +28,7 @@ namespace Take.Elephant.Tests.Kafka
         [Fact]
         public void KafkaSenderQueue_BootstrapCtorWithKafkaSerializer_ShouldCreateInstance()
         {
-            var serializer = Substitute.For<ISerializer<TestItem>>();
+            var serializer = Substitute.For<Take.Elephant.ISerializer<TestItem>>();
             var kafkaSerializer = Substitute.For<Confluent.Kafka.ISerializer<string>>();
 
             var queue = new KafkaSenderQueue<TestItem>(
@@ -46,7 +46,7 @@ namespace Take.Elephant.Tests.Kafka
         public void KafkaSenderQueue_WithIProducerCtor_ShouldCreateInstance()
         {
             var producer = Substitute.For<IProducer<Null, string>>();
-            var serializer = Substitute.For<ISerializer<TestItem>>();
+            var serializer = Substitute.For<Take.Elephant.ISerializer<TestItem>>();
 
             var queue = new KafkaSenderQueue<TestItem>(producer, serializer, "topic-a");
 
@@ -114,6 +114,42 @@ namespace Take.Elephant.Tests.Kafka
         }
 
         [Fact]
+        public void KafkaEventStreamPublisher_WithSerializerCtor_ShouldThrowForNullSerializer()
+        {
+            var producerConfig = new ProducerConfig { BootstrapServers = "localhost:9092" };
+
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new KafkaEventStreamPublisher<string, TestItem>(producerConfig, "topic-a", (Take.Elephant.ISerializer<TestItem>)null)
+            );
+
+            Assert.Equal("serializer", exception.ParamName);
+        }
+
+        [Fact]
+        public void KafkaEventStreamPublisher_WithSerializerCtor_ShouldThrowForNullProducerConfig()
+        {
+            var serializer = Substitute.For<Take.Elephant.ISerializer<TestItem>>();
+
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new KafkaEventStreamPublisher<string, TestItem>((ProducerConfig)null, "topic-a", serializer)
+            );
+
+            Assert.Equal("producerConfig", exception.ParamName);
+        }
+
+        [Fact]
+        public void KafkaEventStreamPublisher_WithKafkaSerializerCtor_ShouldThrowForNullKafkaSerializer()
+        {
+            var producerConfig = new ProducerConfig { BootstrapServers = "localhost:9092" };
+
+            var exception = Assert.Throws<ArgumentNullException>(
+                () => new KafkaEventStreamPublisher<string, TestItem>(producerConfig, "topic-a", (Confluent.Kafka.ISerializer<TestItem>)null)
+            );
+
+            Assert.Equal("kafkaSerializer", exception.ParamName);
+        }
+
+        [Fact]
         public async Task KafkaEventStreamPublisher_WithHeaderProviderReturningNull_ShouldKeepEmptyHeaders()
         {
             var producer = Substitute.For<IProducer<string, TestItem>>();
@@ -138,8 +174,7 @@ namespace Take.Elephant.Tests.Kafka
             await publisher.PublishAsync("key-1", new TestItem(), CancellationToken.None);
 
             Assert.NotNull(capturedMessage);
-            Assert.NotNull(capturedMessage.Headers);
-            Assert.Empty(capturedMessage.Headers);
+            Assert.Null(capturedMessage.Headers);
 
             publisher.Dispose();
         }

--- a/src/Take.Elephant.Tests/Kafka/KafkaSenderAndSchemaRegistryCoverageFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaSenderAndSchemaRegistryCoverageFacts.cs
@@ -1,0 +1,199 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using NSubstitute;
+using Take.Elephant.Kafka;
+using Take.Elephant.Kafka.SchemaRegistry;
+using Xunit;
+
+namespace Take.Elephant.Tests.Kafka
+{
+    [Trait("Category", nameof(Kafka))]
+    public class KafkaSenderAndSchemaRegistryCoverageFacts
+    {
+        [Fact]
+        public void KafkaSenderQueue_BootstrapCtor_ShouldCreateInstance()
+        {
+            var serializer = Substitute.For<ISerializer<TestItem>>();
+
+            var queue = new KafkaSenderQueue<TestItem>("localhost:9092", "topic-a", serializer);
+
+            Assert.Equal("topic-a", queue.Topic);
+            queue.Dispose();
+        }
+
+        [Fact]
+        public void KafkaSenderQueue_BootstrapCtorWithKafkaSerializer_ShouldCreateInstance()
+        {
+            var serializer = Substitute.For<ISerializer<TestItem>>();
+            var kafkaSerializer = Substitute.For<Confluent.Kafka.ISerializer<string>>();
+
+            var queue = new KafkaSenderQueue<TestItem>(
+                "localhost:9092",
+                "topic-a",
+                serializer,
+                kafkaSerializer
+            );
+
+            Assert.Equal("topic-a", queue.Topic);
+            queue.Dispose();
+        }
+
+        [Fact]
+        public void KafkaSenderQueue_WithIProducerCtor_ShouldCreateInstance()
+        {
+            var producer = Substitute.For<IProducer<Null, string>>();
+            var serializer = Substitute.For<ISerializer<TestItem>>();
+
+            var queue = new KafkaSenderQueue<TestItem>(producer, serializer, "topic-a");
+
+            Assert.Equal("topic-a", queue.Topic);
+            queue.Dispose();
+        }
+
+        [Fact]
+        public void KafkaSchemaRegistrySenderQueue_WithIProducerCtor_ShouldThrowForWhitespaceTopic()
+        {
+            var producer = Substitute.For<IProducer<Null, TestItem>>();
+
+            Assert.Throws<ArgumentException>(
+                () => new KafkaSchemaRegistrySenderQueue<TestItem>(producer, " ")
+            );
+        }
+
+        [Fact]
+        public async Task KafkaSchemaRegistrySenderQueue_WithHeaderProvider_ShouldInjectHeadersOnEnqueue()
+        {
+            var producer = Substitute.For<IProducer<Null, TestItem>>();
+            var headerProvider = Substitute.For<IKafkaHeaderProvider>();
+            headerProvider
+                .GetHeaders()
+                .Returns(
+                    new List<IHeader>
+                    {
+                        new Header("x-origin", Encoding.UTF8.GetBytes("billing"))
+                    }
+                );
+
+            Message<Null, TestItem> capturedMessage = null;
+            producer
+                .ProduceAsync(
+                    Arg.Any<string>(),
+                    Arg.Do<Message<Null, TestItem>>(m => capturedMessage = m),
+                    Arg.Any<CancellationToken>()
+                )
+                .Returns(Task.FromResult(new DeliveryResult<Null, TestItem>()));
+
+            var queue = new KafkaSchemaRegistrySenderQueue<TestItem>(
+                producer,
+                "topic-a",
+                schemaRegistryClient: null,
+                headerProvider: headerProvider
+            );
+
+            await queue.EnqueueAsync(new TestItem(), CancellationToken.None);
+
+            Assert.NotNull(capturedMessage);
+            Assert.NotNull(capturedMessage.Headers);
+            Assert.Single(capturedMessage.Headers);
+            Assert.Equal("x-origin", capturedMessage.Headers[0].Key);
+            Assert.Equal("billing", Encoding.UTF8.GetString(capturedMessage.Headers[0].GetValueBytes()));
+
+            queue.Dispose();
+        }
+
+        [Fact]
+        public void KafkaEventStreamPublisher_WithIProducerCtor_ShouldThrowForNullProducer()
+        {
+            Assert.Throws<ArgumentNullException>(
+                () => new KafkaEventStreamPublisher<string, TestItem>(null, "topic-a")
+            );
+        }
+
+        [Fact]
+        public async Task KafkaEventStreamPublisher_WithHeaderProviderReturningNull_ShouldKeepEmptyHeaders()
+        {
+            var producer = Substitute.For<IProducer<string, TestItem>>();
+            var headerProvider = Substitute.For<IKafkaHeaderProvider>();
+            headerProvider.GetHeaders().Returns((IEnumerable<IHeader>)null);
+
+            Message<string, TestItem> capturedMessage = null;
+            producer
+                .ProduceAsync(
+                    Arg.Any<string>(),
+                    Arg.Do<Message<string, TestItem>>(m => capturedMessage = m),
+                    Arg.Any<CancellationToken>()
+                )
+                .Returns(Task.FromResult(new DeliveryResult<string, TestItem>()));
+
+            var publisher = new KafkaEventStreamPublisher<string, TestItem>(
+                producer,
+                "topic-a",
+                headerProvider
+            );
+
+            await publisher.PublishAsync("key-1", new TestItem(), CancellationToken.None);
+
+            Assert.NotNull(capturedMessage);
+            Assert.NotNull(capturedMessage.Headers);
+            Assert.Empty(capturedMessage.Headers);
+
+            publisher.Dispose();
+        }
+
+        [Fact]
+        public async Task KafkaEventStreamPublisher_WithInvalidHeaders_ShouldIgnoreInvalidAndKeepValid()
+        {
+            var producer = Substitute.For<IProducer<string, TestItem>>();
+            var headerProvider = Substitute.For<IKafkaHeaderProvider>();
+
+            var nullKeyHeader = Substitute.For<IHeader>();
+            nullKeyHeader.Key.Returns((string)null);
+            nullKeyHeader.GetValueBytes().Returns(Encoding.UTF8.GetBytes("ignored"));
+
+            headerProvider
+                .GetHeaders()
+                .Returns(
+                    new List<IHeader>
+                    {
+                        null,
+                        nullKeyHeader,
+                        new Header("x-origin", Encoding.UTF8.GetBytes("billing")),
+                    }
+                );
+
+            Message<string, TestItem> capturedMessage = null;
+            producer
+                .ProduceAsync(
+                    Arg.Any<string>(),
+                    Arg.Do<Message<string, TestItem>>(m => capturedMessage = m),
+                    Arg.Any<CancellationToken>()
+                )
+                .Returns(Task.FromResult(new DeliveryResult<string, TestItem>()));
+
+            var publisher = new KafkaEventStreamPublisher<string, TestItem>(
+                producer,
+                "topic-a",
+                headerProvider
+            );
+
+            await publisher.PublishAsync("key-1", new TestItem(), CancellationToken.None);
+
+            Assert.NotNull(capturedMessage);
+            Assert.NotNull(capturedMessage.Headers);
+            Assert.Single(capturedMessage.Headers);
+            Assert.Equal("x-origin", capturedMessage.Headers[0].Key);
+            Assert.Equal("billing", Encoding.UTF8.GetString(capturedMessage.Headers[0].GetValueBytes()));
+
+            publisher.Dispose();
+        }
+
+        public sealed class TestItem
+        {
+            public string Value { get; set; }
+        }
+    }
+}

--- a/src/Take.Elephant.Tests/Kafka/KafkaSenderQueueAndConsumedMessageFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaSenderQueueAndConsumedMessageFacts.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -17,7 +18,7 @@ namespace Take.Elephant.Tests.Kafka
         public async Task KafkaSenderQueue_WithEventStreamPublisherCtor_ShouldSetPropertiesAndEnqueue()
         {
             var publisher = Substitute.For<IEventStreamPublisher<Null, string>>();
-            var serializer = Substitute.For<ISerializer<TestItem>>();
+            var serializer = Substitute.For<Take.Elephant.ISerializer<TestItem>>();
             serializer.Serialize(Arg.Any<TestItem>()).Returns("serialized");
 
             var queue = new KafkaSenderQueue<TestItem>(publisher, serializer, "topic-a");
@@ -31,7 +32,7 @@ namespace Take.Elephant.Tests.Kafka
         [Fact]
         public void KafkaSenderQueue_WithEventStreamPublisherCtor_ShouldThrowWhenProducerIsNull()
         {
-            var serializer = Substitute.For<ISerializer<TestItem>>();
+            var serializer = Substitute.For<Take.Elephant.ISerializer<TestItem>>();
 
             var ex = Assert.Throws<ArgumentNullException>(
                 () => new KafkaSenderQueue<TestItem>((IEventStreamPublisher<Null, string>)null, serializer, "topic-a")
@@ -56,7 +57,7 @@ namespace Take.Elephant.Tests.Kafka
         public void KafkaSenderQueue_WithEventStreamPublisherCtor_ShouldThrowWhenTopicIsNull()
         {
             var publisher = Substitute.For<IEventStreamPublisher<Null, string>>();
-            var serializer = Substitute.For<ISerializer<TestItem>>();
+            var serializer = Substitute.For<Take.Elephant.ISerializer<TestItem>>();
 
             var ex = Assert.Throws<ArgumentNullException>(
                 () => new KafkaSenderQueue<TestItem>(publisher, serializer, null)
@@ -91,6 +92,56 @@ namespace Take.Elephant.Tests.Kafka
         }
 
         [Fact]
+        public void KafkaConsumedMessage_ShouldCloneHeaderValuesOnConstruction()
+        {
+            var sourceBytes = new byte[] { 1, 2, 3 };
+            var headers = new Dictionary<string, byte[]>
+            {
+                ["x-key"] = sourceBytes
+            };
+
+            var consumed = new KafkaConsumedMessage<TestItem>(new TestItem(), headers);
+            sourceBytes[0] = 9;
+
+            Assert.True(consumed.TryGetHeader("x-key", out var actual));
+            Assert.Equal(new byte[] { 1, 2, 3 }, actual);
+        }
+
+        [Fact]
+        public void KafkaConsumedMessage_TryGetHeader_ShouldReturnClonedValue()
+        {
+            var headers = new Dictionary<string, byte[]>
+            {
+                ["x-key"] = new byte[] { 1, 2, 3 }
+            };
+            var consumed = new KafkaConsumedMessage<TestItem>(new TestItem(), headers);
+
+            Assert.True(consumed.TryGetHeader("x-key", out var firstRead));
+            firstRead[0] = 9;
+
+            Assert.True(consumed.TryGetHeader("x-key", out var secondRead));
+            Assert.Equal(new byte[] { 1, 2, 3 }, secondRead);
+        }
+
+        [Fact]
+        public void KafkaConsumedMessage_WithTrustedHeaders_ShouldReuseProvidedValues()
+        {
+            var headerValue = new byte[] { 1, 2, 3 };
+            IReadOnlyDictionary<string, byte[]> headers =
+                new ReadOnlyDictionary<string, byte[]>(new Dictionary<string, byte[]>
+                {
+                    ["x-key"] = headerValue
+                });
+
+            var consumed = new KafkaConsumedMessage<TestItem>(new TestItem(), headers, headersAreSafe: true);
+
+            Assert.Same(headerValue, consumed.Headers["x-key"]);
+            Assert.True(consumed.TryGetHeader("x-key", out var headerCopy));
+            Assert.NotSame(headerValue, headerCopy);
+            Assert.Equal(headerValue, headerCopy);
+        }
+
+        [Fact]
         public void KafkaConsumedMessage_TryGetHeader_ShouldReturnFalseForNullOrWhitespaceKey()
         {
             var consumed = new KafkaConsumedMessage<TestItem>(new TestItem(), new Dictionary<string, byte[]>());
@@ -100,6 +151,9 @@ namespace Take.Elephant.Tests.Kafka
             Assert.False(consumed.TryGetHeader("   ", out _));
         }
 
-        public sealed class TestItem { }
+        public sealed class TestItem
+        {
+            public string Value { get; set; }
+        }
     }
 }

--- a/src/Take.Elephant.Tests/Kafka/KafkaSenderQueueAndConsumedMessageFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaSenderQueueAndConsumedMessageFacts.cs
@@ -1,0 +1,105 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using NSubstitute;
+using Take.Elephant.Kafka;
+using Xunit;
+
+namespace Take.Elephant.Tests.Kafka
+{
+    [Trait("Category", nameof(Kafka))]
+    public class KafkaSenderQueueAndConsumedMessageFacts
+    {
+        [Fact]
+        public async Task KafkaSenderQueue_WithEventStreamPublisherCtor_ShouldSetPropertiesAndEnqueue()
+        {
+            var publisher = Substitute.For<IEventStreamPublisher<Null, string>>();
+            var serializer = Substitute.For<ISerializer<TestItem>>();
+            serializer.Serialize(Arg.Any<TestItem>()).Returns("serialized");
+
+            var queue = new KafkaSenderQueue<TestItem>(publisher, serializer, "topic-a");
+
+            Assert.Equal("topic-a", queue.Topic);
+            await queue.EnqueueAsync(new TestItem(), CancellationToken.None);
+
+            await publisher.Received(1).PublishAsync(null, "serialized", CancellationToken.None);
+        }
+
+        [Fact]
+        public void KafkaSenderQueue_WithEventStreamPublisherCtor_ShouldThrowWhenProducerIsNull()
+        {
+            var serializer = Substitute.For<ISerializer<TestItem>>();
+
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => new KafkaSenderQueue<TestItem>((IEventStreamPublisher<Null, string>)null, serializer, "topic-a")
+            );
+
+            Assert.Equal("producer", ex.ParamName);
+        }
+
+        [Fact]
+        public void KafkaSenderQueue_WithEventStreamPublisherCtor_ShouldThrowWhenSerializerIsNull()
+        {
+            var publisher = Substitute.For<IEventStreamPublisher<Null, string>>();
+
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => new KafkaSenderQueue<TestItem>(publisher, null, "topic-a")
+            );
+
+            Assert.Equal("serializer", ex.ParamName);
+        }
+
+        [Fact]
+        public void KafkaSenderQueue_WithEventStreamPublisherCtor_ShouldThrowWhenTopicIsNull()
+        {
+            var publisher = Substitute.For<IEventStreamPublisher<Null, string>>();
+            var serializer = Substitute.For<ISerializer<TestItem>>();
+
+            var ex = Assert.Throws<ArgumentNullException>(
+                () => new KafkaSenderQueue<TestItem>(publisher, serializer, null)
+            );
+
+            Assert.Equal("topic", ex.ParamName);
+        }
+
+        [Fact]
+        public void KafkaConsumedMessage_WithNullHeaders_ShouldExposeEmptyReadOnlyHeaders()
+        {
+            var consumed = new KafkaConsumedMessage<TestItem>(new TestItem(), null);
+
+            Assert.Empty(consumed.Headers);
+            Assert.False(consumed.TryGetHeader("x-missing", out _));
+            Assert.False(consumed.TryGetHeaderAsUtf8String("x-missing", out _));
+        }
+
+        [Fact]
+        public void KafkaConsumedMessage_TryGetHeader_ShouldReturnTrueWhenHeaderExists()
+        {
+            var expectedBytes = Encoding.UTF8.GetBytes("value-1");
+            var headers = new Dictionary<string, byte[]>
+            {
+                ["x-key"] = expectedBytes
+            };
+
+            var consumed = new KafkaConsumedMessage<TestItem>(new TestItem(), headers);
+
+            Assert.True(consumed.TryGetHeader("x-key", out var actual));
+            Assert.Equal(expectedBytes, actual);
+        }
+
+        [Fact]
+        public void KafkaConsumedMessage_TryGetHeader_ShouldReturnFalseForNullOrWhitespaceKey()
+        {
+            var consumed = new KafkaConsumedMessage<TestItem>(new TestItem(), new Dictionary<string, byte[]>());
+
+            Assert.False(consumed.TryGetHeader(null, out _));
+            Assert.False(consumed.TryGetHeader("", out _));
+            Assert.False(consumed.TryGetHeader("   ", out _));
+        }
+
+        public sealed class TestItem { }
+    }
+}


### PR DESCRIPTION
## Summary

Extends Kafka consumers and producers to support message headers on an opt-in basis. Adds `IKafkaReceiverQueue<T>` interface with `DequeueWithHeadersAsync()` / `DequeueWithHeadersOrDefaultAsync()` methods that return a new `KafkaConsumedMessage<T>` envelope containing both payload and headers. Producers accept optional `IKafkaHeaderProvider` for dynamic header injection. Legacy `DequeueAsync()` behavior is preserved when headers are not needed.

Additionally stabilizes Kafka integration tests by removing unsafe pre-join offset commits, using unique topic/group pairs per test run, explicit topic creation via Admin API, and `Earliest` offset reset to eliminate race conditions.

## Motivation

- **Consumer headers:** Enables tracing, correlation ID propagation, and other header-based metadata without breaking existing dequeue patterns.
- **Producer headers:** Allows dynamic header injection (e.g., trace IDs, deployment tags) at the library level.
- **Test stability:** Prior integration tests were unreliable due to group state mismanagement and broker auto-create races; explicit isolation makes them deterministic.

## Changes

### Core Producer/Consumer APIs

- **New:** `IKafkaReceiverQueue<T>` interface with header-aware dequeue methods.
- **New:** `KafkaConsumedMessage<T>` envelope with `Item` and `Headers` properties; includes `TryGetHeader()` and `TryGetHeaderAsUtf8String()` helpers.
- **New:** `IKafkaHeaderProvider` interface for header composition.
- **Modified:** `KafkaReceiverQueue<T>`, `KafkaSchemaRegistryReceiverQueue<T>` now implement `IKafkaReceiverQueue<T>`.
- **Modified:** `KafkaPartitionQueue<T>`, `KafkaSchemaRegistryPartitionQueue<T>` now expose header dequeue methods.
- **Modified:** Producer classes (`KafkaSenderQueue<T>`, `KafkaEventStreamPublisher<TKey, TEvent>`, etc.) accept optional `IKafkaHeaderProvider` parameter.

### Test Improvements

- **KafkaItemSenderReceiverQueueFacts.cs:** Uses unique topic/group per test, explicit topic creation, `Earliest` offset reset.
- **KafkaItemEventStreamPublisherConsumerFacts.cs:** Same isolation strategy.
- **KafkaReceiverQueueHeadersFacts.cs:** New unit test suite covering header read/write and no-header backward compatibility.

## Risk

**Low.** All changes are additive and defensive:

- Existing `DequeueAsync()` / `DequeueOrDefaultAsync()` calls remain unchanged (no signature breaking).
- Header injection is conditional; when `IKafkaHeaderProvider` is `null`, producers behave identically to before.
- Test isolation (unique topic/group) affects only test reliability, not production code paths.
- Header reading requires explicit opt-in via `IKafkaReceiverQueue<T>` cast.

## Test Evidence

```text
dotnet test src/Take.Elephant.Tests/Take.Elephant.Tests.csproj --filter "FullyQualifiedName~Kafka"
Passed!  - Failed: 0, Passed: 69, Skipped: 0, Total: 69, Duration: 32s

Specifically:
  - KafkaReceiverQueueHeadersFacts:  Passed 4/4 (header read, no-header compat)
  - KafkaItemSenderReceiverQueueFacts: Passed 9/9 (isolated topics/groups)
  - KafkaItemEventStreamPublisherConsumerFacts: Passed 5/5 (isolated topics/groups)
  - All other Kafka-related tests: Passed
```

## Rollback

- Delete new files: `KafkaConsumedMessage.cs`, `IKafkaReceiverQueue.cs`, `IKafkaHeaderProvider.cs`, test file `KafkaReceiverQueueHeadersFacts.cs`.
- Revert modified files to remove `IKafkaHeaderProvider` parameters and header-dequeue methods.
- Restore test files to shared `items` topic + static `default` group (original, unstable behavior).