### PR TITLE
feat: add ackable message support with OnSuccess and Manual ack modes

### DIFF
--- a/src/Take.Elephant.Kafka/IKafkaAckableReceiverQueue.cs
+++ b/src/Take.Elephant.Kafka/IKafkaAckableReceiverQueue.cs
@@ -1,0 +1,27 @@
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Take.Elephant.Kafka
+{
+    /// <summary>
+    /// Extended Kafka receiver contract that exposes ackable messages.
+    /// Consumers that require acknowledgement control (OnSuccess or Manual modes)
+    /// should use <see cref="DequeueAckableAsync"/> or <see cref="DequeueAckableOrDefaultAsync"/>.
+    /// </summary>
+    /// <typeparam name="T">Payload type.</typeparam>
+    public interface IKafkaAckableReceiverQueue<T> : IKafkaReceiverQueue<T>
+    {
+        /// <summary>
+        /// Dequeues an ackable message, awaiting for a new value if the queue is empty.
+        /// The returned <see cref="KafkaAckableMessage{T}"/> must be acknowledged after
+        /// successful processing.
+        /// </summary>
+        Task<KafkaAckableMessage<T>> DequeueAckableAsync(CancellationToken cancellationToken);
+
+        /// <summary>
+        /// Dequeues an ackable message if available; returns <see langword="null"/> otherwise.
+        /// </summary>
+        Task<KafkaAckableMessage<T>> DequeueAckableOrDefaultAsync(CancellationToken cancellationToken = default);
+    }
+}

--- a/src/Take.Elephant.Kafka/IKafkaAckableReceiverQueue.cs
+++ b/src/Take.Elephant.Kafka/IKafkaAckableReceiverQueue.cs
@@ -4,34 +4,14 @@ using System.Threading.Tasks;
 namespace Take.Elephant.Kafka
 {
     /// <summary>
-    /// Kafka receiver contract that exposes ackable messages for
-    /// <see cref="KafkaAckMode.OnSuccess"/> and <see cref="KafkaAckMode.Manual"/> modes.
+    /// Kafka receiver contract for <see cref="KafkaAckMode.OnSuccess"/> and <see cref="KafkaAckMode.Manual"/> modes.
+    /// Intentionally not derived from <see cref="IKafkaReceiverQueue{T}"/> — non-Eager implementations
+    /// throw on the legacy Dequeue* methods, which would violate LSP.
     /// </summary>
-    /// <remarks>
-    /// This interface is intentionally <b>not</b> derived from
-    /// <see cref="IKafkaReceiverQueue{T}"/> because <see cref="KafkaReceiverQueue{T}"/>
-    /// throws <see cref="System.InvalidOperationException"/> from the
-    /// <c>DequeueAsync</c> / <c>DequeueOrDefault*</c> / <c>DequeueWithHeaders*</c> members
-    /// in non-Eager modes. Deriving from the base interface would violate the
-    /// Liskov Substitution Principle: code typed against <see cref="IKafkaReceiverQueue{T}"/>
-    /// could receive an <see cref="IKafkaAckableReceiverQueue{T}"/> and fail at runtime.
-    /// <para>
-    /// <see cref="KafkaReceiverQueue{T}"/> implements both interfaces with publicly accessible
-    /// methods. Declare your dependency as <see cref="IKafkaReceiverQueue{T}"/> for Eager mode,
-    /// or as <see cref="IKafkaAckableReceiverQueue{T}"/> for OnSuccess / Manual modes.
-    /// Prefer the <see cref="KafkaReceiverQueue"/> static factory class, which returns the
-    /// narrowest interface for the requested mode and makes accidental misregistration a
-    /// compile-time error instead of a runtime failure.
-    /// </para>
-    /// </remarks>
     /// <typeparam name="T">Payload type.</typeparam>
     public interface IKafkaAckableReceiverQueue<T>
     {
-        /// <summary>
-        /// Dequeues an ackable message, awaiting for a new value if the queue is empty.
-        /// The returned <see cref="KafkaAckableMessage{T}"/> must be acknowledged after
-        /// successful processing.
-        /// </summary>
+        /// <summary>Dequeues an ackable message, waiting if the queue is empty. Must be acknowledged after processing.</summary>
         Task<KafkaAckableMessage<T>> DequeueAckableAsync(CancellationToken cancellationToken);
 
         /// <summary>

--- a/src/Take.Elephant.Kafka/IKafkaAckableReceiverQueue.cs
+++ b/src/Take.Elephant.Kafka/IKafkaAckableReceiverQueue.cs
@@ -1,16 +1,31 @@
-using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 
 namespace Take.Elephant.Kafka
 {
     /// <summary>
-    /// Extended Kafka receiver contract that exposes ackable messages.
-    /// Consumers that require acknowledgement control (OnSuccess or Manual modes)
-    /// should use <see cref="DequeueAckableAsync"/> or <see cref="DequeueAckableOrDefaultAsync"/>.
+    /// Kafka receiver contract that exposes ackable messages for
+    /// <see cref="KafkaAckMode.OnSuccess"/> and <see cref="KafkaAckMode.Manual"/> modes.
     /// </summary>
+    /// <remarks>
+    /// This interface is intentionally <b>not</b> derived from
+    /// <see cref="IKafkaReceiverQueue{T}"/> because <see cref="KafkaReceiverQueue{T}"/>
+    /// throws <see cref="System.InvalidOperationException"/> from the
+    /// <c>DequeueAsync</c> / <c>DequeueOrDefault*</c> / <c>DequeueWithHeaders*</c> members
+    /// in non-Eager modes. Deriving from the base interface would violate the
+    /// Liskov Substitution Principle: code typed against <see cref="IKafkaReceiverQueue{T}"/>
+    /// could receive an <see cref="IKafkaAckableReceiverQueue{T}"/> and fail at runtime.
+    /// <para>
+    /// <see cref="KafkaReceiverQueue{T}"/> implements both interfaces with publicly accessible
+    /// methods. Declare your dependency as <see cref="IKafkaReceiverQueue{T}"/> for Eager mode,
+    /// or as <see cref="IKafkaAckableReceiverQueue{T}"/> for OnSuccess / Manual modes.
+    /// Prefer the <see cref="KafkaReceiverQueue"/> static factory class, which returns the
+    /// narrowest interface for the requested mode and makes accidental misregistration a
+    /// compile-time error instead of a runtime failure.
+    /// </para>
+    /// </remarks>
     /// <typeparam name="T">Payload type.</typeparam>
-    public interface IKafkaAckableReceiverQueue<T> : IKafkaReceiverQueue<T>
+    public interface IKafkaAckableReceiverQueue<T>
     {
         /// <summary>
         /// Dequeues an ackable message, awaiting for a new value if the queue is empty.

--- a/src/Take.Elephant.Kafka/KafkaAckMode.cs
+++ b/src/Take.Elephant.Kafka/KafkaAckMode.cs
@@ -1,0 +1,32 @@
+namespace Take.Elephant.Kafka
+{
+    /// <summary>
+    /// Controls when the Kafka consumer offset is committed.
+    /// </summary>
+    public enum KafkaAckMode
+    {
+        /// <summary>
+        /// Legacy default. Auto-commit is managed by the Confluent client
+        /// (<c>enable.auto.commit=true</c>). Offset is committed periodically
+        /// regardless of processing outcome. If the offset is auto-committed
+        /// before processing completes, a crash before completion may cause
+        /// message loss (message committed but not processed).
+        /// </summary>
+        Eager = 0,
+
+        /// <summary>
+        /// Offset is stored only after the caller explicitly invokes
+        /// <see cref="KafkaAckableMessage{T}.AcknowledgeAsync"/> following
+        /// successful processing. If the POD restarts before ack, the message
+        /// will be redelivered.
+        /// </summary>
+        OnSuccess = 1,
+
+        /// <summary>
+        /// Same as <see cref="OnSuccess"/> but the caller has full, explicit control
+        /// over when to acknowledge. Useful when acknowledgement depends on downstream
+        /// conditions (e.g., waiting for a secondary confirmation).
+        /// </summary>
+        Manual = 2,
+    }
+}

--- a/src/Take.Elephant.Kafka/KafkaAckMode.cs
+++ b/src/Take.Elephant.Kafka/KafkaAckMode.cs
@@ -15,10 +15,10 @@ namespace Take.Elephant.Kafka
         Eager = 0,
 
         /// <summary>
-        /// Offset is stored only after the caller explicitly invokes
-        /// <see cref="KafkaAckableMessage{T}.AcknowledgeAsync"/> following
-        /// successful processing. If the POD restarts before ack, the message
-        /// will be redelivered.
+        /// Offset is committed to the broker only after the caller explicitly invokes
+        /// <see cref="KafkaAckableMessage{T}.AcknowledgeAsync"/> following successful
+        /// processing. If the process restarts before ack, the message will be
+        /// redelivered (at-least-once delivery guarantee).
         /// </summary>
         OnSuccess = 1,
 

--- a/src/Take.Elephant.Kafka/KafkaAckMode.cs
+++ b/src/Take.Elephant.Kafka/KafkaAckMode.cs
@@ -6,26 +6,20 @@ namespace Take.Elephant.Kafka
     public enum KafkaAckMode
     {
         /// <summary>
-        /// Legacy default. Auto-commit is managed by the Confluent client
-        /// (<c>enable.auto.commit=true</c>). Offset is committed periodically
-        /// regardless of processing outcome. If the offset is auto-committed
-        /// before processing completes, a crash before completion may cause
-        /// message loss (message committed but not processed).
+        /// Legacy default. Offset committed by Confluent auto-commit before processing completes.
+        /// A pod crash after commit but before processing finishes causes silent message loss.
         /// </summary>
         Eager = 0,
 
         /// <summary>
-        /// Offset is committed to the broker only after the caller explicitly invokes
-        /// <see cref="KafkaAckableMessage{T}.AcknowledgeAsync"/> following successful
-        /// processing. If the process restarts before ack, the message will be
-        /// redelivered (at-least-once delivery guarantee).
+        /// Offset committed only after <see cref="KafkaAckableMessage{T}.AcknowledgeAsync"/> is called.
+        /// At-least-once delivery: message is redelivered if the process restarts before ack.
         /// </summary>
         OnSuccess = 1,
 
         /// <summary>
-        /// Same as <see cref="OnSuccess"/> but the caller has full, explicit control
-        /// over when to acknowledge. Useful when acknowledgement depends on downstream
-        /// conditions (e.g., waiting for a secondary confirmation).
+        /// Same semantics as <see cref="OnSuccess"/>; the name signals that acknowledgement
+        /// timing is fully controlled by the application.
         /// </summary>
         Manual = 2,
     }

--- a/src/Take.Elephant.Kafka/KafkaAckableMessage.cs
+++ b/src/Take.Elephant.Kafka/KafkaAckableMessage.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Take.Elephant.Kafka
+{
+    /// <summary>
+    /// A Kafka message that carries the payload, headers, and a delegate to acknowledge the offset.
+    /// The acknowledge operation commits the offset to the broker immediately via
+    /// <c>StoreOffset</c> + synchronous <c>Commit</c>. Call <see cref="AcknowledgeAsync"/>
+    /// only after the business processing is fully completed.
+    /// </summary>
+    /// <typeparam name="T">Payload type.</typeparam>
+    public sealed class KafkaAckableMessage<T>
+    {
+        private readonly Func<CancellationToken, Task> _acknowledge;
+        private int _acknowledged;
+
+        public KafkaAckableMessage(
+            T item,
+            IReadOnlyDictionary<string, byte[]> headers,
+            string topic,
+            int partition,
+            long offset,
+            Func<CancellationToken, Task> acknowledge)
+        {
+            Item = item;
+            Headers = headers ?? KafkaConsumedMessageDefaults.EmptyHeaders;
+            Topic = topic;
+            Partition = partition;
+            Offset = offset;
+            _acknowledge = acknowledge ?? throw new ArgumentNullException(nameof(acknowledge));
+        }
+
+        /// <summary>The deserialized payload.</summary>
+        public T Item { get; }
+
+        /// <summary>Kafka message headers.</summary>
+        public IReadOnlyDictionary<string, byte[]> Headers { get; }
+
+        /// <summary>Topic the message was consumed from.</summary>
+        public string Topic { get; }
+
+        /// <summary>Partition the message was consumed from.</summary>
+        public int Partition { get; }
+
+        /// <summary>Offset of the message in the partition.</summary>
+        public long Offset { get; }
+
+        /// <summary>Whether this message has already been acknowledged.</summary>
+        public bool IsAcknowledged => _acknowledged == 1;
+
+        /// <summary>
+        /// Stores the offset for commit. Idempotent: subsequent calls are no-ops.
+        /// </summary>
+        public Task AcknowledgeAsync(CancellationToken cancellationToken = default)
+        {
+            if (Interlocked.CompareExchange(ref _acknowledged, 1, 0) == 0)
+            {
+                return _acknowledge(cancellationToken);
+            }
+
+            return Task.CompletedTask;
+        }
+    }
+}

--- a/src/Take.Elephant.Kafka/KafkaAckableMessage.cs
+++ b/src/Take.Elephant.Kafka/KafkaAckableMessage.cs
@@ -6,10 +6,8 @@ using System.Threading.Tasks;
 namespace Take.Elephant.Kafka
 {
     /// <summary>
-    /// A Kafka message that carries the payload, headers, and a delegate to acknowledge the offset.
-    /// The acknowledge operation commits the offset to the broker immediately via synchronous
-    /// <c>Commit(IEnumerable&lt;TopicPartitionOffset&gt;)</c>, bypassing the local offset store.
-    /// Call <see cref="AcknowledgeAsync"/> only after the business processing is fully completed.
+    /// A Kafka message envelope with payload, headers, and an <see cref="AcknowledgeAsync"/> delegate
+    /// that commits the offset to the broker. Call only after processing is fully complete.
     /// </summary>
     /// <typeparam name="T">Payload type.</typeparam>
     public sealed class KafkaAckableMessage<T>
@@ -33,29 +31,21 @@ namespace Take.Elephant.Kafka
             _acknowledge = acknowledge ?? throw new ArgumentNullException(nameof(acknowledge));
         }
 
-        /// <summary>The deserialized payload.</summary>
         public T Item { get; }
 
-        /// <summary>Kafka message headers.</summary>
         public IReadOnlyDictionary<string, byte[]> Headers { get; }
 
-        /// <summary>Topic the message was consumed from.</summary>
         public string Topic { get; }
 
-        /// <summary>Partition the message was consumed from.</summary>
         public int Partition { get; }
 
-        /// <summary>Offset of the message in the partition.</summary>
         public long Offset { get; }
 
-        /// <summary>Whether this message has already been acknowledged.</summary>
         public bool IsAcknowledged => _acknowledged == 1;
 
         /// <summary>
-        /// Acknowledges the message by committing its offset to the broker.
-        /// Idempotent: once the commit succeeds, subsequent calls are no-ops.
-        /// If the commit throws, <see cref="IsAcknowledged"/> remains <see langword="false"/>
-        /// so the caller may retry by calling this method again.
+        /// Commits the offset to the broker. Idempotent on success; if the commit throws,
+        /// <see cref="IsAcknowledged"/> remains <see langword="false"/> allowing retry.
         /// </summary>
         public Task AcknowledgeAsync(CancellationToken cancellationToken = default)
         {

--- a/src/Take.Elephant.Kafka/KafkaAckableMessage.cs
+++ b/src/Take.Elephant.Kafka/KafkaAckableMessage.cs
@@ -44,9 +44,16 @@ namespace Take.Elephant.Kafka
         public bool IsAcknowledged => _acknowledged == 1;
 
         /// <summary>
-        /// Commits the offset to the broker. Idempotent on success; if the commit throws,
-        /// <see cref="IsAcknowledged"/> remains <see langword="false"/> allowing retry.
+        /// Advances the local HWM and, when all preceding offsets are contiguous, commits to the broker.
+        /// The commit may be suppressed if earlier offsets are still pending, or if the partition was
+        /// revoked or the consumer closed before this call completed.
+        /// Idempotent on success; if the commit throws, <see cref="IsAcknowledged"/> remains
+        /// <see langword="false"/> so the caller can retry on the same instance.
         /// </summary>
+        /// <remarks>
+        /// Not safe for concurrent calls on the same instance. Each <see cref="KafkaAckableMessage{T}"/>
+        /// is intended to be owned and acknowledged by a single task.
+        /// </remarks>
         public Task AcknowledgeAsync(CancellationToken cancellationToken = default)
         {
             // Fast path: already successfully acknowledged — no-op.

--- a/src/Take.Elephant.Kafka/KafkaAckableMessage.cs
+++ b/src/Take.Elephant.Kafka/KafkaAckableMessage.cs
@@ -7,9 +7,9 @@ namespace Take.Elephant.Kafka
 {
     /// <summary>
     /// A Kafka message that carries the payload, headers, and a delegate to acknowledge the offset.
-    /// The acknowledge operation commits the offset to the broker immediately via
-    /// <c>StoreOffset</c> + synchronous <c>Commit</c>. Call <see cref="AcknowledgeAsync"/>
-    /// only after the business processing is fully completed.
+    /// The acknowledge operation commits the offset to the broker immediately via synchronous
+    /// <c>Commit(IEnumerable&lt;TopicPartitionOffset&gt;)</c>, bypassing the local offset store.
+    /// Call <see cref="AcknowledgeAsync"/> only after the business processing is fully completed.
     /// </summary>
     /// <typeparam name="T">Payload type.</typeparam>
     public sealed class KafkaAckableMessage<T>
@@ -52,16 +52,32 @@ namespace Take.Elephant.Kafka
         public bool IsAcknowledged => _acknowledged == 1;
 
         /// <summary>
-        /// Stores the offset for commit. Idempotent: subsequent calls are no-ops.
+        /// Acknowledges the message by committing its offset to the broker.
+        /// Idempotent: once the commit succeeds, subsequent calls are no-ops.
+        /// If the commit throws, <see cref="IsAcknowledged"/> remains <see langword="false"/>
+        /// so the caller may retry by calling this method again.
         /// </summary>
         public Task AcknowledgeAsync(CancellationToken cancellationToken = default)
         {
-            if (Interlocked.CompareExchange(ref _acknowledged, 1, 0) == 0)
-            {
-                return _acknowledge(cancellationToken);
-            }
+            // Fast path: already successfully acknowledged — no-op.
+            if (Interlocked.CompareExchange(ref _acknowledged, 1, 0) != 0)
+                return Task.CompletedTask;
 
-            return Task.CompletedTask;
+            return AcknowledgeWithResetOnFailureAsync(cancellationToken);
+        }
+
+        private async Task AcknowledgeWithResetOnFailureAsync(CancellationToken cancellationToken)
+        {
+            try
+            {
+                await _acknowledge(cancellationToken);
+            }
+            catch
+            {
+                // Reset the flag so the caller can retry the commit on the same message.
+                Interlocked.Exchange(ref _acknowledged, 0);
+                throw;
+            }
         }
     }
 }

--- a/src/Take.Elephant.Kafka/KafkaHeadersConverter.cs
+++ b/src/Take.Elephant.Kafka/KafkaHeadersConverter.cs
@@ -37,5 +37,11 @@ namespace Take.Elephant.Kafka
 
             return new ReadOnlyDictionary<string, byte[]>(result);
         }
+
+        /// <summary>
+        /// Alias for <see cref="ToDictionary"/> — exposed for ackable message construction.
+        /// </summary>
+        internal static IReadOnlyDictionary<string, byte[]> ToReadOnlyDictionary(Headers headers)
+            => ToDictionary(headers);
     }
 }

--- a/src/Take.Elephant.Kafka/KafkaHeadersConverter.cs
+++ b/src/Take.Elephant.Kafka/KafkaHeadersConverter.cs
@@ -38,9 +38,6 @@ namespace Take.Elephant.Kafka
             return new ReadOnlyDictionary<string, byte[]>(result);
         }
 
-        /// <summary>
-        /// Alias for <see cref="ToDictionary"/> — exposed for ackable message construction.
-        /// </summary>
         internal static IReadOnlyDictionary<string, byte[]> ToReadOnlyDictionary(Headers headers)
             => ToDictionary(headers);
     }

--- a/src/Take.Elephant.Kafka/KafkaReceiverQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaReceiverQueue.cs
@@ -1,6 +1,7 @@
 using Confluent.Kafka;
 using Newtonsoft.Json;
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
@@ -10,13 +11,27 @@ using System.Threading.Tasks;
 
 namespace Take.Elephant.Kafka
 {
-    public class KafkaReceiverQueue<T> : IKafkaReceiverQueue<T>, IOpenable, ICloseable, IDisposable
+    /// <summary>
+    /// Kafka receiver queue that supports three acknowledgement modes:
+    /// <list type="bullet">
+    ///   <item><see cref="KafkaAckMode.Eager"/> — legacy default: auto-commit managed by Confluent client.</item>
+    ///   <item><see cref="KafkaAckMode.OnSuccess"/> — offset is stored only after <see cref="DequeueAckableAsync"/> returns and the caller invokes <see cref="KafkaAckableMessage{T}.AcknowledgeAsync"/>.</item>
+    ///   <item><see cref="KafkaAckMode.Manual"/> — same as OnSuccess but the application controls when to ack independently of the pipeline.</item>
+    /// </list>
+    /// </summary>
+    public class KafkaReceiverQueue<T> : IKafkaAckableReceiverQueue<T>, IOpenable, ICloseable, IDisposable
     {
-        private readonly IConsumer<Ignore, string> _consumer;
-        private readonly ISerializer<T> _serializer;
-        private readonly SemaphoreSlim _consumerStartSemaphore;
-        private readonly CancellationTokenSource _cts;
-        private readonly Channel<(T Item, Headers KafkaHeaders)> _channel;
+        private IConsumer<Ignore, string> _consumer;
+        private ISerializer<T> _serializer;
+        private KafkaAckMode _ackMode;
+        // Per-partition commit trackers — one instance per assigned partition (OnSuccess/Manual only)
+        private ConcurrentDictionary<TopicPartition, PartitionCommitTracker> _partitionTrackers;
+        private SemaphoreSlim _consumerStartSemaphore;
+        private CancellationTokenSource _cts;
+        // Eager channel: (Item, Headers)
+        private Channel<(T Item, Headers KafkaHeaders)> _channel;
+        // Ackable channel: includes partition/offset and the per-partition tracker snapshot
+        private Channel<(T Item, Headers KafkaHeaders, TopicPartition Partition, long Offset, PartitionCommitTracker Tracker)> _ackableChannel;
         private Task _consumerTask;
         private bool _closed;
 
@@ -29,32 +44,107 @@ namespace Take.Elephant.Kafka
             ConsumerConfig consumerConfig,
             string topic,
             ISerializer<T> serializer,
-            IDeserializer<string> deserializer = null)
-            : this(
-                  new ConsumerBuilder<Ignore, string>(consumerConfig)
-                      .SetValueDeserializer(deserializer ?? new StringDeserializer())
-                      .Build(),
-                  serializer,
-                  topic)
+            IDeserializer<string> deserializer = null,
+            KafkaAckMode ackMode = KafkaAckMode.Eager)
         {
+            ConcurrentDictionary<TopicPartition, PartitionCommitTracker> partitionTrackers = null;
+            if (ackMode != KafkaAckMode.Eager)
+            {
+                // Disable auto-commit so we control offset stores
+                consumerConfig = new ConsumerConfig(consumerConfig)
+                {
+                    EnableAutoCommit = false,
+                    EnableAutoOffsetStore = false,
+                };
+                // Create the dictionary before wiring the handlers so the closures
+                // capture the same reference that Initialize() will store.
+                partitionTrackers = new ConcurrentDictionary<TopicPartition, PartitionCommitTracker>();
+            }
+
+            var builder = new ConsumerBuilder<Ignore, string>(consumerConfig)
+                .SetValueDeserializer(deserializer ?? new StringDeserializer());
+
+            if (partitionTrackers != null)
+            {
+                // On assignment: install a fresh tracker for each new partition so
+                // state from any previous assignment cannot block future commits.
+                // On revoke/lost: remove the tracker; the partition is no longer ours.
+                builder = builder
+                    .SetPartitionsAssignedHandler((c, partitions) =>
+                    {
+                        foreach (var tp in partitions)
+                            partitionTrackers[tp] = new PartitionCommitTracker();
+                    })
+                    .SetPartitionsRevokedHandler((c, partitions) =>
+                    {
+                        foreach (var tpo in partitions)
+                            partitionTrackers.TryRemove(tpo.TopicPartition, out _);
+                    })
+                    .SetPartitionsLostHandler((c, partitions) =>
+                    {
+                        foreach (var tpo in partitions)
+                            partitionTrackers.TryRemove(tpo.TopicPartition, out _);
+                    });
+            }
+
+            Initialize(builder.Build(), serializer, topic, ackMode, partitionTrackers);
         }
 
-        public KafkaReceiverQueue(IConsumer<Ignore, string> consumer, ISerializer<T> serializer, string topic)
+        /// <summary>
+        /// Initializes a new instance using an already-built <see cref="IConsumer{TKey, TValue}"/>.
+        /// Intended primarily for testing with mocked consumers.
+        /// </summary>
+        /// <remarks>
+        /// When <paramref name="ackMode"/> is not <see cref="KafkaAckMode.Eager"/>, the caller is
+        /// responsible for ensuring the consumer was built with
+        /// <c>EnableAutoCommit = false</c> and <c>EnableAutoOffsetStore = false</c>.
+        /// If the injected consumer has auto-commit or auto-offset-store enabled,
+        /// offsets will be committed by the Confluent client regardless of
+        /// <see cref="KafkaAckableMessage{T}.AcknowledgeAsync"/> calls,
+        /// silently defeating the at-least-once guarantee.
+        /// For production use, prefer the constructor that accepts <see cref="Confluent.Kafka.ConsumerConfig"/>.
+        /// </remarks>
+        public KafkaReceiverQueue(IConsumer<Ignore, string> consumer, ISerializer<T> serializer, string topic,
+            KafkaAckMode ackMode = KafkaAckMode.Eager)
+        {
+            Initialize(consumer, serializer, topic, ackMode, null);
+        }
+
+        private void Initialize(IConsumer<Ignore, string> consumer, ISerializer<T> serializer, string topic,
+            KafkaAckMode ackMode, ConcurrentDictionary<TopicPartition, PartitionCommitTracker> partitionTrackers)
         {
             if (string.IsNullOrWhiteSpace(topic)) throw new ArgumentException("Value cannot be null or whitespace.", nameof(topic));
             _consumer = consumer ?? throw new ArgumentNullException(nameof(consumer));
             ArgumentNullException.ThrowIfNull(serializer);
             _serializer = serializer;
             Topic = topic;
+            _ackMode = ackMode;
             _consumerStartSemaphore = new SemaphoreSlim(1, 1);
             _cts = new CancellationTokenSource();
-            _channel = Channel.CreateBounded<(T, Headers)>(1);
+
+            if (ackMode == KafkaAckMode.Eager)
+            {
+                _channel = Channel.CreateBounded<(T, Headers)>(1);
+            }
+            else
+            {
+                // Use the pre-created dictionary (which already has rebalance handlers
+                // wired via ConsumerBuilder) or create a fresh one for the IConsumer path.
+                _partitionTrackers = partitionTrackers ?? new ConcurrentDictionary<TopicPartition, PartitionCommitTracker>();
+                _ackableChannel = Channel.CreateBounded<(T, Headers, TopicPartition, long, PartitionCommitTracker)>(1);
+            }
         }
 
-        public string Topic { get; }
+        public string Topic { get; private set; }
 
         public virtual async Task<T> DequeueOrDefaultAsync(CancellationToken cancellationToken = default)
         {
+            if (_ackMode != KafkaAckMode.Eager)
+                throw new InvalidOperationException(
+                    $"{nameof(DequeueOrDefaultAsync)} is not supported when {nameof(KafkaAckMode)} " +
+                    $"is {_ackMode}. Use {nameof(DequeueAckableAsync)} or {nameof(DequeueAckableOrDefaultAsync)} " +
+                    $"to obtain an acknowledgeable handle, otherwise offsets will never be committed.");
+
             await StartConsumerTaskIfNotAsync(cancellationToken);
             if (_channel.Reader.TryRead(out var item))
             {
@@ -66,6 +156,12 @@ namespace Take.Elephant.Kafka
 
         public async Task<KafkaConsumedMessage<T>> DequeueWithHeadersOrDefaultAsync(CancellationToken cancellationToken = default)
         {
+            if (_ackMode != KafkaAckMode.Eager)
+                throw new InvalidOperationException(
+                    $"{nameof(DequeueWithHeadersOrDefaultAsync)} is not supported when {nameof(KafkaAckMode)} " +
+                    $"is {_ackMode}. Use {nameof(DequeueAckableAsync)} or {nameof(DequeueAckableOrDefaultAsync)} " +
+                    $"to obtain an acknowledgeable handle, otherwise offsets will never be committed.");
+
             await StartConsumerTaskIfNotAsync(cancellationToken);
             if (_channel.Reader.TryRead(out var item))
             {
@@ -77,6 +173,12 @@ namespace Take.Elephant.Kafka
 
         public virtual async Task<T> DequeueAsync(CancellationToken cancellationToken)
         {
+            if (_ackMode != KafkaAckMode.Eager)
+                throw new InvalidOperationException(
+                    $"{nameof(DequeueAsync)} is not supported when {nameof(KafkaAckMode)} " +
+                    $"is {_ackMode}. Use {nameof(DequeueAckableAsync)} to obtain an acknowledgeable " +
+                    $"handle, otherwise offsets will never be committed.");
+
             await StartConsumerTaskIfNotAsync(cancellationToken);
             var item = await _channel.Reader.ReadAsync(cancellationToken);
             return item.Item;
@@ -84,9 +186,81 @@ namespace Take.Elephant.Kafka
 
         public async Task<KafkaConsumedMessage<T>> DequeueWithHeadersAsync(CancellationToken cancellationToken)
         {
+            if (_ackMode != KafkaAckMode.Eager)
+                throw new InvalidOperationException(
+                    $"{nameof(DequeueWithHeadersAsync)} is not supported when {nameof(KafkaAckMode)} " +
+                    $"is {_ackMode}. Use {nameof(DequeueAckableAsync)} to obtain an acknowledgeable " +
+                    $"handle, otherwise offsets will never be committed.");
+
             await StartConsumerTaskIfNotAsync(cancellationToken);
             var item = await _channel.Reader.ReadAsync(cancellationToken);
             return KafkaHeadersConverter.BuildConsumedMessage(item.Item, item.KafkaHeaders);
+        }
+
+        // ---- IKafkaAckableReceiverQueue<T> ----
+
+        public async Task<KafkaAckableMessage<T>> DequeueAckableAsync(CancellationToken cancellationToken)
+        {
+            await StartConsumerTaskIfNotAsync(cancellationToken);
+            if (_ackMode == KafkaAckMode.Eager)
+                throw new InvalidOperationException(
+                    $"DequeueAckableAsync requires KafkaAckMode.OnSuccess or Manual. Current mode: {_ackMode}.");
+
+            var entry = await _ackableChannel.Reader.ReadAsync(cancellationToken);
+            return BuildAckableMessage(entry);
+        }
+
+        public async Task<KafkaAckableMessage<T>> DequeueAckableOrDefaultAsync(CancellationToken cancellationToken = default)
+        {
+            await StartConsumerTaskIfNotAsync(cancellationToken);
+            if (_ackMode == KafkaAckMode.Eager)
+                throw new InvalidOperationException(
+                    $"DequeueAckableOrDefaultAsync requires KafkaAckMode.OnSuccess or Manual. Current mode: {_ackMode}.");
+
+            if (_ackableChannel.Reader.TryRead(out var entry))
+                return BuildAckableMessage(entry);
+
+            return null;
+        }
+
+        private KafkaAckableMessage<T> BuildAckableMessage(
+            (T Item, Headers KafkaHeaders, TopicPartition Partition, long Offset, PartitionCommitTracker Tracker) entry)
+        {
+            var tp = entry.Partition;
+            var offset = entry.Offset;
+            // Capture the tracker instance at message-creation time (not the field).
+            // If a rebalance happens before AcknowledgeAsync is called, the delegate
+            // still references the OLD tracker for this partition; the new assignment
+            // gets a brand-new tracker instance. Any commit attempted on the old
+            // partition after revocation throws a KafkaException, which we catch below.
+            var capturedTracker = entry.Tracker;
+            var headers = KafkaHeadersConverter.ToReadOnlyDictionary(entry.KafkaHeaders);
+            return new KafkaAckableMessage<T>(
+                entry.Item,
+                headers,
+                tp.Topic,
+                tp.Partition.Value,
+                offset,
+                _ =>
+                {
+                    var commitOffset = capturedTracker.Acknowledge(offset);
+                    if (commitOffset.HasValue)
+                    {
+                        try
+                        {
+                            var tpo = new TopicPartitionOffset(tp, new Offset(commitOffset.Value));
+                            _consumer.StoreOffset(tpo);
+                            _consumer.Commit(new[] { tpo });
+                        }
+                        catch (KafkaException)
+                        {
+                            // The partition was revoked or rebalanced before the commit
+                            // could be persisted. Kafka will redeliver these messages to
+                            // the new owner — safe to discard this exception.
+                        }
+                    }
+                    return Task.CompletedTask;
+                });
         }
 
         public Task OpenAsync(CancellationToken cancellationToken)
@@ -162,7 +336,24 @@ namespace Take.Elephant.Kafka
                 {
                     var result = _consumer.Consume(cancellationToken);
                     var resultValue = _serializer.Deserialize(result.Message.Value);
-                    await _channel.Writer.WriteAsync((resultValue, result.Message.Headers), cancellationToken);
+
+                    if (_ackMode == KafkaAckMode.Eager)
+                    {
+                        await _channel.Writer.WriteAsync((resultValue, result.Message.Headers), cancellationToken);
+                    }
+                    else
+                    {
+                        var tp = result.TopicPartition;
+                        var offset = result.Offset.Value;
+                        // Obtain (or lazily create) the per-partition tracker, then
+                        // record the offset before pushing the message to the channel
+                        // so no ack can race ahead of its Track() call.
+                        var tracker = _partitionTrackers.GetOrAdd(tp, _ => new PartitionCommitTracker());
+                        tracker.Track(offset);
+                        await _ackableChannel.Writer.WriteAsync(
+                            (resultValue, result.Message.Headers, tp, offset, tracker),
+                            cancellationToken);
+                    }
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
                 {
@@ -183,7 +374,10 @@ namespace Take.Elephant.Kafka
             }
 
             _consumer.Unsubscribe();
-            _channel.Writer.Complete();
+            if (_ackMode == KafkaAckMode.Eager)
+                _channel.Writer.Complete();
+            else
+                _ackableChannel.Writer.Complete();
         }
 
         public void Dispose()

--- a/src/Take.Elephant.Kafka/KafkaReceiverQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaReceiverQueue.cs
@@ -14,7 +14,9 @@ namespace Take.Elephant.Kafka
     /// <summary>
     /// Kafka receiver queue with three offset-commit modes: <see cref="KafkaAckMode.Eager"/> (auto-commit),
     /// <see cref="KafkaAckMode.OnSuccess"/>, and <see cref="KafkaAckMode.Manual"/>.
-    /// Prefer the <see cref="KafkaReceiverQueue"/> static factory for type-safe construction.
+    /// Prefer the <see cref="KafkaReceiverQueue"/> static factory to guarantee the correct ack-mode
+    /// configuration is applied; direct constructor calls may bypass required settings such as
+    /// <c>EnableAutoCommit = false</c>.
     /// </summary>
     public class KafkaReceiverQueue<T> : IKafkaAckableReceiverQueue<T>, IKafkaReceiverQueue<T>, IOpenable, ICloseable, IDisposable
     {
@@ -533,6 +535,14 @@ namespace Take.Elephant.Kafka
     /// Factory for <see cref="KafkaReceiverQueue{T}"/>. Returns the concrete type so callers
     /// retain access to lifecycle operations such as <see cref="KafkaReceiverQueue{T}.OpenAsync"/>,
     /// <see cref="KafkaReceiverQueue{T}.CloseAsync"/>, and <see cref="KafkaReceiverQueue{T}.Dispose"/>.
+    /// <para>
+    /// Note: <see cref="KafkaReceiverQueue{T}"/> implements both <see cref="IKafkaReceiverQueue{T}"/>
+    /// and <see cref="IKafkaAckableReceiverQueue{T}"/>. Assigning a non-Eager instance to
+    /// <see cref="IKafkaReceiverQueue{T}"/> and calling <c>Dequeue*</c> methods will throw
+    /// <see cref="InvalidOperationException"/> at runtime. Always use the concrete type or
+    /// <see cref="IKafkaAckableReceiverQueue{T}"/> for <see cref="KafkaAckMode.OnSuccess"/>
+    /// and <see cref="KafkaAckMode.Manual"/> instances.
+    /// </para>
     /// </summary>
     public static class KafkaReceiverQueue
     {

--- a/src/Take.Elephant.Kafka/KafkaReceiverQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaReceiverQueue.cs
@@ -41,7 +41,8 @@ namespace Take.Elephant.Kafka
         }
 
         // IDeserializer<string> is required (not optional) to avoid CLR ambiguity with the 5-param overload above.
-        public KafkaReceiverQueue(string bootstrapServers, string topic, string groupId, ISerializer<T> serializer, IDeserializer<string> deserializer, KafkaAckMode ackMode)
+        // internal: callers must use KafkaReceiverQueue.Create* factory to get the correct narrowed interface.
+        internal KafkaReceiverQueue(string bootstrapServers, string topic, string groupId, ISerializer<T> serializer, IDeserializer<string> deserializer, KafkaAckMode ackMode)
             : this(new ConsumerConfig() { BootstrapServers = bootstrapServers, GroupId = groupId }, topic, serializer, deserializer, ackMode)
         {
         }
@@ -53,7 +54,8 @@ namespace Take.Elephant.Kafka
         }
 
         // IDeserializer<string> is required (not optional) to avoid CLR ambiguity with the 4-param overload above.
-        public KafkaReceiverQueue(
+        // internal: callers must use KafkaReceiverQueue.Create* factory to get the correct narrowed interface.
+        internal KafkaReceiverQueue(
             ConsumerConfig consumerConfig,
             string topic,
             ISerializer<T> serializer,
@@ -441,22 +443,41 @@ namespace Take.Elephant.Kafka
                 try
                 {
                     var result = _consumer.Consume(cancellationToken);
-                    var resultValue = _serializer.Deserialize(result.Message.Value);
 
                     if (_ackMode == KafkaAckMode.Eager)
                     {
+                        var resultValue = _serializer.Deserialize(result.Message.Value);
                         await _channel.Writer.WriteAsync((resultValue, result.Message.Headers), cancellationToken);
                     }
                     else
                     {
                         var tp = result.TopicPartition;
                         var offset = result.Offset.Value;
-                        // Track before channel write: no ack can race ahead of its Track() call.
                         var tracker = _partitionTrackers.GetOrAdd(tp, _ => new PartitionCommitTracker());
+                        // Track before deserialize: if Deserialize throws for offset N, the tracker
+                        // would never see N, allowing the next offset to bootstrap/advance past it
+                        // and silently skip the poison record on commit.
                         tracker.Track(offset);
+                        T resultValue;
+                        try
+                        {
+                            resultValue = _serializer.Deserialize(result.Message.Value);
+                        }
+                        catch
+                        {
+                            // Auto-advance HWM past the poison record so the tracker never blocks
+                            // future commits waiting for an offset that will never be acked.
+                            // The exception still propagates to the ConsumerFailed handler.
+                            tracker.Acknowledge(offset);
+                            throw;
+                        }
+                        // Track before channel write: no ack can race ahead of its Track() call.
                         await _ackableChannel.Writer.WriteAsync(
                             (resultValue, result.Message.Headers, tp, offset, tracker),
                             cancellationToken);
+                        // Clear the state-machine field so a revoked tracker becomes GC-eligible
+                        // before the loop blocks again at _consumer.Consume().
+                        tracker = null;
                     }
                 }
                 catch (OperationCanceledException) when (cancellationToken.IsCancellationRequested)
@@ -509,37 +530,38 @@ namespace Take.Elephant.Kafka
     }
 
     /// <summary>
-    /// Type-safe factory for <see cref="KafkaReceiverQueue{T}"/>. Returns the narrowest interface
-    /// for the requested <see cref="KafkaAckMode"/>, making accidental DI misregistration a compile-time error.
+    /// Factory for <see cref="KafkaReceiverQueue{T}"/>. Returns the concrete type so callers
+    /// retain access to lifecycle operations such as <see cref="KafkaReceiverQueue{T}.OpenAsync"/>,
+    /// <see cref="KafkaReceiverQueue{T}.CloseAsync"/>, and <see cref="KafkaReceiverQueue{T}.Dispose"/>.
     /// </summary>
     public static class KafkaReceiverQueue
     {
-        public static IKafkaReceiverQueue<T> CreateEager<T>(
+        public static KafkaReceiverQueue<T> CreateEager<T>(
             string bootstrapServers, string topic, string groupId,
             ISerializer<T> serializer, IDeserializer<string> deserializer = null)
             => new KafkaReceiverQueue<T>(bootstrapServers, topic, groupId, serializer, deserializer, KafkaAckMode.Eager);
 
-        public static IKafkaReceiverQueue<T> CreateEager<T>(
+        public static KafkaReceiverQueue<T> CreateEager<T>(
             ConsumerConfig config, string topic,
             ISerializer<T> serializer, IDeserializer<string> deserializer = null)
             => new KafkaReceiverQueue<T>(config, topic, serializer, deserializer, KafkaAckMode.Eager);
 
-        public static IKafkaAckableReceiverQueue<T> CreateOnSuccess<T>(
+        public static KafkaReceiverQueue<T> CreateOnSuccess<T>(
             string bootstrapServers, string topic, string groupId,
             ISerializer<T> serializer, IDeserializer<string> deserializer = null)
             => new KafkaReceiverQueue<T>(bootstrapServers, topic, groupId, serializer, deserializer, KafkaAckMode.OnSuccess);
 
-        public static IKafkaAckableReceiverQueue<T> CreateOnSuccess<T>(
+        public static KafkaReceiverQueue<T> CreateOnSuccess<T>(
             ConsumerConfig config, string topic,
             ISerializer<T> serializer, IDeserializer<string> deserializer = null)
             => new KafkaReceiverQueue<T>(config, topic, serializer, deserializer, KafkaAckMode.OnSuccess);
 
-        public static IKafkaAckableReceiverQueue<T> CreateManual<T>(
+        public static KafkaReceiverQueue<T> CreateManual<T>(
             string bootstrapServers, string topic, string groupId,
             ISerializer<T> serializer, IDeserializer<string> deserializer = null)
             => new KafkaReceiverQueue<T>(bootstrapServers, topic, groupId, serializer, deserializer, KafkaAckMode.Manual);
 
-        public static IKafkaAckableReceiverQueue<T> CreateManual<T>(
+        public static KafkaReceiverQueue<T> CreateManual<T>(
             ConsumerConfig config, string topic,
             ISerializer<T> serializer, IDeserializer<string> deserializer = null)
             => new KafkaReceiverQueue<T>(config, topic, serializer, deserializer, KafkaAckMode.Manual);

--- a/src/Take.Elephant.Kafka/KafkaReceiverQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaReceiverQueue.cs
@@ -15,17 +15,50 @@ namespace Take.Elephant.Kafka
     /// Kafka receiver queue that supports three acknowledgement modes:
     /// <list type="bullet">
     ///   <item><see cref="KafkaAckMode.Eager"/> — legacy default: auto-commit managed by Confluent client.</item>
-    ///   <item><see cref="KafkaAckMode.OnSuccess"/> — offset is stored only after <see cref="DequeueAckableAsync"/> returns and the caller invokes <see cref="KafkaAckableMessage{T}.AcknowledgeAsync"/>.</item>
-    ///   <item><see cref="KafkaAckMode.Manual"/> — same as OnSuccess but the application controls when to ack independently of the pipeline.</item>
+    ///   <item><see cref="KafkaAckMode.OnSuccess"/> — offset committed only after the caller invokes <see cref="KafkaAckableMessage{T}.AcknowledgeAsync"/>.</item>
+    ///   <item><see cref="KafkaAckMode.Manual"/> — same as OnSuccess but acknowledgement timing is fully application-controlled.</item>
     /// </list>
     /// </summary>
-    public class KafkaReceiverQueue<T> : IKafkaAckableReceiverQueue<T>, IOpenable, ICloseable, IDisposable
+    /// <remarks>
+    /// This class implements both <see cref="IKafkaReceiverQueue{T}"/> and
+    /// <see cref="IKafkaAckableReceiverQueue{T}"/>. The two interfaces are mode-exclusive;
+    /// calling the wrong family of Dequeue methods throws <see cref="InvalidOperationException"/>.
+    /// <para>
+    /// <b>Preferred construction:</b> use the <see cref="KafkaReceiverQueue"/> static factory class
+    /// instead of calling <c>new KafkaReceiverQueue&lt;T&gt;(...)</c> directly. The factory methods
+    /// return the narrowest interface that matches the requested mode, turning accidental
+    /// DI-container misregistration into a compile-time error rather than a runtime failure.
+    /// </para>
+    /// <code>
+    /// // Eager (auto-commit) — returns IKafkaReceiverQueue&lt;T&gt;
+    /// IKafkaReceiverQueue&lt;Order&gt; q = KafkaReceiverQueue.CreateEager&lt;Order&gt;(config, topic, s);
+    ///
+    /// // OnSuccess / Manual — returns IKafkaAckableReceiverQueue&lt;T&gt;
+    /// IKafkaAckableReceiverQueue&lt;Order&gt; q = KafkaReceiverQueue.CreateOnSuccess&lt;Order&gt;(config, topic, s);
+    ///
+    /// // The following is a COMPILE ERROR — compile-time protection against misregistration:
+    /// // IKafkaReceiverQueue&lt;Order&gt; q = KafkaReceiverQueue.CreateOnSuccess&lt;Order&gt;(…);
+    /// </code>
+    /// </remarks>
+    public class KafkaReceiverQueue<T> : IKafkaAckableReceiverQueue<T>, IKafkaReceiverQueue<T>, IOpenable, ICloseable, IDisposable
     {
         private IConsumer<Ignore, string> _consumer;
         private ISerializer<T> _serializer;
         private KafkaAckMode _ackMode;
         // Per-partition commit trackers — one instance per assigned partition (OnSuccess/Manual only)
         private ConcurrentDictionary<TopicPartition, PartitionCommitTracker> _partitionTrackers;
+        // Per-partition commit serialization (OnSuccess/Manual only).
+        // Ensures only one Commit() call is in flight per partition at a time, preventing
+        // a slower lower-offset commit from moving the broker cursor backwards when
+        // multiple messages are acknowledged concurrently.
+        private ConcurrentDictionary<TopicPartition, SemaphoreSlim> _partitionCommitLocks;
+        // Per-partition highest offset value we have committed so far (OnSuccess/Manual only).
+        // Used inside the per-partition commit lock to skip commits that are no longer the
+        // highest — guards against a slow Commit(N) arriving after a fast Commit(M > N) and
+        // regressing the broker cursor.
+        private ConcurrentDictionary<TopicPartition, long> _partitionMaxCommitted;
+        // Sentinel that represents "no broker commit has been issued for this partition yet."
+        private const long NoCommitsYet = long.MinValue;
         private SemaphoreSlim _consumerStartSemaphore;
         private CancellationTokenSource _cts;
         // Eager channel: (Item, Headers)
@@ -33,21 +66,44 @@ namespace Take.Elephant.Kafka
         // Ackable channel: includes partition/offset and the per-partition tracker snapshot
         private Channel<(T Item, Headers KafkaHeaders, TopicPartition Partition, long Offset, PartitionCommitTracker Tracker)> _ackableChannel;
         private Task _consumerTask;
-        private bool _closed;
+        private volatile bool _closed;
 
+        // ── Binary-compatible overload: preserves the original 5-param CLR signature.
+        // Assemblies compiled against the previous NuGet version of this library call
+        // the constructor without ackMode. This explicit overload keeps those binaries
+        // working after the package upgrade (defaults to Eager auto-commit).
         public KafkaReceiverQueue(string bootstrapServers, string topic, string groupId, ISerializer<T> serializer, IDeserializer<string> deserializer = null)
-            : this(new ConsumerConfig() { BootstrapServers = bootstrapServers, GroupId = groupId }, topic, serializer, deserializer)
+            : this(bootstrapServers, topic, groupId, serializer, deserializer, KafkaAckMode.Eager)
         {
         }
 
+        // New overload that accepts an explicit ackMode.
+        // IDeserializer<string> is required (not optional) to avoid CLR ambiguity with the
+        // binary-compatible 5-param overload above.
+        public KafkaReceiverQueue(string bootstrapServers, string topic, string groupId, ISerializer<T> serializer, IDeserializer<string> deserializer, KafkaAckMode ackMode)
+            : this(new ConsumerConfig() { BootstrapServers = bootstrapServers, GroupId = groupId }, topic, serializer, deserializer, ackMode)
+        {
+        }
+
+        // ── Binary-compatible overload: preserves the original 4-param CLR signature.
+        public KafkaReceiverQueue(ConsumerConfig consumerConfig, string topic, ISerializer<T> serializer, IDeserializer<string> deserializer = null)
+            : this(consumerConfig, topic, serializer, deserializer, KafkaAckMode.Eager)
+        {
+        }
+
+        // New overload that accepts an explicit ackMode.
+        // IDeserializer<string> is required (not optional) to avoid CLR ambiguity with the
+        // binary-compatible 4-param overload above.
         public KafkaReceiverQueue(
             ConsumerConfig consumerConfig,
             string topic,
             ISerializer<T> serializer,
-            IDeserializer<string> deserializer = null,
-            KafkaAckMode ackMode = KafkaAckMode.Eager)
+            IDeserializer<string> deserializer,
+            KafkaAckMode ackMode)
         {
             ConcurrentDictionary<TopicPartition, PartitionCommitTracker> partitionTrackers = null;
+            ConcurrentDictionary<TopicPartition, SemaphoreSlim> partitionCommitLocks = null;
+            ConcurrentDictionary<TopicPartition, long> partitionMaxCommitted = null;
             if (ackMode != KafkaAckMode.Eager)
             {
                 // Disable auto-commit so we control offset stores
@@ -56,9 +112,11 @@ namespace Take.Elephant.Kafka
                     EnableAutoCommit = false,
                     EnableAutoOffsetStore = false,
                 };
-                // Create the dictionary before wiring the handlers so the closures
-                // capture the same reference that Initialize() will store.
+                // Create the dictionaries before wiring the handlers so the closures
+                // capture the same references that Initialize() will store.
                 partitionTrackers = new ConcurrentDictionary<TopicPartition, PartitionCommitTracker>();
+                partitionCommitLocks = new ConcurrentDictionary<TopicPartition, SemaphoreSlim>();
+                partitionMaxCommitted = new ConcurrentDictionary<TopicPartition, long>();
             }
 
             var builder = new ConsumerBuilder<Ignore, string>(consumerConfig)
@@ -66,52 +124,113 @@ namespace Take.Elephant.Kafka
 
             if (partitionTrackers != null)
             {
-                // On assignment: install a fresh tracker for each new partition so
-                // state from any previous assignment cannot block future commits.
-                // On revoke/lost: remove the tracker; the partition is no longer ours.
+                // On assignment: install a fresh tracker + commit state for each new partition
+                // so that state from any previous assignment cannot block future commits.
+                // On revoke/lost: remove all per-partition state; the partition is no longer
+                // ours, so Kafka will redeliver to the new owner.
                 builder = builder
                     .SetPartitionsAssignedHandler((c, partitions) =>
                     {
                         foreach (var tp in partitions)
+                        {
                             partitionTrackers[tp] = new PartitionCommitTracker();
+                            partitionCommitLocks[tp] = new SemaphoreSlim(1, 1);
+                            partitionMaxCommitted[tp] = NoCommitsYet;
+                        }
                     })
                     .SetPartitionsRevokedHandler((c, partitions) =>
                     {
                         foreach (var tpo in partitions)
-                            partitionTrackers.TryRemove(tpo.TopicPartition, out _);
+                        {
+                            var tp = tpo.TopicPartition;
+                            partitionTrackers.TryRemove(tp, out _);
+                            // The SemaphoreSlim is intentionally NOT disposed here: in-flight
+                            // ack delegates may still be waiting on it when revoke fires, and
+                            // disposing a SemaphoreSlim with waiters throws ObjectDisposedException.
+                            // The GC collects the instance once all waiters release.
+                            partitionCommitLocks.TryRemove(tp, out _);
+                            partitionMaxCommitted.TryRemove(tp, out _);
+                        }
                     })
                     .SetPartitionsLostHandler((c, partitions) =>
                     {
                         foreach (var tpo in partitions)
-                            partitionTrackers.TryRemove(tpo.TopicPartition, out _);
+                        {
+                            var tp = tpo.TopicPartition;
+                            partitionTrackers.TryRemove(tp, out _);
+                            partitionCommitLocks.TryRemove(tp, out _); // same note as above
+                            partitionMaxCommitted.TryRemove(tp, out _);
+                        }
                     });
             }
 
-            Initialize(builder.Build(), serializer, topic, ackMode, partitionTrackers);
+            Initialize(builder.Build(), serializer, topic, ackMode, partitionTrackers, partitionCommitLocks, partitionMaxCommitted);
         }
 
         /// <summary>
         /// Initializes a new instance using an already-built <see cref="IConsumer{TKey, TValue}"/>.
-        /// Intended primarily for testing with mocked consumers.
+        /// Only <see cref="KafkaAckMode.Eager"/> is accepted; passing any other mode throws
+        /// <see cref="ArgumentException"/> because a consumer injected from outside cannot be
+        /// guaranteed to have <c>EnableAutoCommit = false</c> and <c>EnableAutoOffsetStore = false</c>,
+        /// which are required for at-least-once delivery.
+        /// For <see cref="KafkaAckMode.OnSuccess"/> or <see cref="KafkaAckMode.Manual"/>, use the
+        /// constructor that accepts <see cref="Confluent.Kafka.ConsumerConfig"/>.
         /// </summary>
         /// <remarks>
-        /// When <paramref name="ackMode"/> is not <see cref="KafkaAckMode.Eager"/>, the caller is
-        /// responsible for ensuring the consumer was built with
-        /// <c>EnableAutoCommit = false</c> and <c>EnableAutoOffsetStore = false</c>.
-        /// If the injected consumer has auto-commit or auto-offset-store enabled,
-        /// offsets will be committed by the Confluent client regardless of
-        /// <see cref="KafkaAckableMessage{T}.AcknowledgeAsync"/> calls,
-        /// silently defeating the at-least-once guarantee.
-        /// For production use, prefer the constructor that accepts <see cref="Confluent.Kafka.ConsumerConfig"/>.
+        /// Binary-compatible overload. Calls <see cref="KafkaReceiverQueue{T}(IConsumer{Ignore,string},ISerializer{T},string,KafkaAckMode)"/>
+        /// with <see cref="KafkaAckMode.Eager"/>.
         /// </remarks>
+        public KafkaReceiverQueue(IConsumer<Ignore, string> consumer, ISerializer<T> serializer, string topic)
+            : this(consumer, serializer, topic, KafkaAckMode.Eager)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance using an already-built <see cref="IConsumer{TKey, TValue}"/>.
+        /// Only <see cref="KafkaAckMode.Eager"/> is accepted; passing any other mode throws
+        /// <see cref="ArgumentException"/> because a consumer injected from outside cannot be
+        /// guaranteed to have <c>EnableAutoCommit = false</c> and <c>EnableAutoOffsetStore = false</c>,
+        /// which are required for at-least-once delivery.
+        /// For <see cref="KafkaAckMode.OnSuccess"/> or <see cref="KafkaAckMode.Manual"/>, use the
+        /// constructor that accepts <see cref="Confluent.Kafka.ConsumerConfig"/>.
+        /// </summary>
+        /// <exception cref="ArgumentException">
+        /// Thrown when <paramref name="ackMode"/> is not <see cref="KafkaAckMode.Eager"/>.
+        /// </exception>
         public KafkaReceiverQueue(IConsumer<Ignore, string> consumer, ISerializer<T> serializer, string topic,
             KafkaAckMode ackMode = KafkaAckMode.Eager)
         {
-            Initialize(consumer, serializer, topic, ackMode, null);
+            if (ackMode != KafkaAckMode.Eager)
+                throw new ArgumentException(
+                    $"Only {nameof(KafkaAckMode)}.{KafkaAckMode.Eager} is supported when injecting an " +
+                    $"{nameof(IConsumer<Ignore, string>)} directly. For {ackMode} use the constructor " +
+                    $"that accepts {nameof(ConsumerConfig)} so that EnableAutoCommit and " +
+                    $"EnableAutoOffsetStore are enforced automatically.",
+                    nameof(ackMode));
+
+            Initialize(consumer, serializer, topic, ackMode, null, null, null);
         }
 
-        private void Initialize(IConsumer<Ignore, string> consumer, ISerializer<T> serializer, string topic,
+        /// <summary>
+        /// Internal constructor used exclusively by unit tests that need to inject a mocked consumer
+        /// with a non-Eager <see cref="KafkaAckMode"/>.
+        /// The caller must ensure the mock is configured with <c>EnableAutoCommit = false</c> and
+        /// <c>EnableAutoOffsetStore = false</c> to preserve the at-least-once guarantee.
+        /// </summary>
+        internal KafkaReceiverQueue(IConsumer<Ignore, string> consumer, ISerializer<T> serializer, string topic,
             KafkaAckMode ackMode, ConcurrentDictionary<TopicPartition, PartitionCommitTracker> partitionTrackers)
+        {
+            Initialize(consumer, serializer, topic, ackMode, partitionTrackers, null, null);
+        }
+
+        private void Initialize(
+            IConsumer<Ignore, string> consumer,
+            ISerializer<T> serializer,
+            string topic,
+            KafkaAckMode ackMode,
+            ConcurrentDictionary<TopicPartition, PartitionCommitTracker> partitionTrackers,
+            ConcurrentDictionary<TopicPartition, SemaphoreSlim> partitionCommitLocks,
+            ConcurrentDictionary<TopicPartition, long> partitionMaxCommitted)
         {
             if (string.IsNullOrWhiteSpace(topic)) throw new ArgumentException("Value cannot be null or whitespace.", nameof(topic));
             _consumer = consumer ?? throw new ArgumentNullException(nameof(consumer));
@@ -128,9 +247,11 @@ namespace Take.Elephant.Kafka
             }
             else
             {
-                // Use the pre-created dictionary (which already has rebalance handlers
-                // wired via ConsumerBuilder) or create a fresh one for the IConsumer path.
+                // Use the pre-created dictionaries (which already have rebalance handlers
+                // wired via ConsumerBuilder) or create fresh ones for the IConsumer path.
                 _partitionTrackers = partitionTrackers ?? new ConcurrentDictionary<TopicPartition, PartitionCommitTracker>();
+                _partitionCommitLocks = partitionCommitLocks ?? new ConcurrentDictionary<TopicPartition, SemaphoreSlim>();
+                _partitionMaxCommitted = partitionMaxCommitted ?? new ConcurrentDictionary<TopicPartition, long>();
                 _ackableChannel = Channel.CreateBounded<(T, Headers, TopicPartition, long, PartitionCommitTracker)>(1);
             }
         }
@@ -201,21 +322,22 @@ namespace Take.Elephant.Kafka
 
         public async Task<KafkaAckableMessage<T>> DequeueAckableAsync(CancellationToken cancellationToken)
         {
-            await StartConsumerTaskIfNotAsync(cancellationToken);
             if (_ackMode == KafkaAckMode.Eager)
                 throw new InvalidOperationException(
                     $"DequeueAckableAsync requires KafkaAckMode.OnSuccess or Manual. Current mode: {_ackMode}.");
 
+            await StartConsumerTaskIfNotAsync(cancellationToken);
             var entry = await _ackableChannel.Reader.ReadAsync(cancellationToken);
             return BuildAckableMessage(entry);
         }
 
         public async Task<KafkaAckableMessage<T>> DequeueAckableOrDefaultAsync(CancellationToken cancellationToken = default)
         {
-            await StartConsumerTaskIfNotAsync(cancellationToken);
             if (_ackMode == KafkaAckMode.Eager)
                 throw new InvalidOperationException(
                     $"DequeueAckableOrDefaultAsync requires KafkaAckMode.OnSuccess or Manual. Current mode: {_ackMode}.");
+
+            await StartConsumerTaskIfNotAsync(cancellationToken);
 
             if (_ackableChannel.Reader.TryRead(out var entry))
                 return BuildAckableMessage(entry);
@@ -235,31 +357,115 @@ namespace Take.Elephant.Kafka
             // partition after revocation throws a KafkaException, which we catch below.
             var capturedTracker = entry.Tracker;
             var headers = KafkaHeadersConverter.ToReadOnlyDictionary(entry.KafkaHeaders);
+
+            // Cached commit offset: set the first time Acknowledge() computes the HWM;
+            // reused on retry if the preceding Commit() call threw an exception.
+            // The tracker's HWM has already advanced at that point, so re-calling
+            // capturedTracker.Acknowledge(offset) would return null on a retry.
+            long? cachedCommitOffset = null;
+
             return new KafkaAckableMessage<T>(
                 entry.Item,
                 headers,
                 tp.Topic,
                 tp.Partition.Value,
                 offset,
-                _ =>
+                async ct =>
                 {
-                    var commitOffset = capturedTracker.Acknowledge(offset);
-                    if (commitOffset.HasValue)
+                    // Use cached value from a previous failed attempt, or compute fresh via tracker.
+                    var commitOffset = cachedCommitOffset ?? capturedTracker.Acknowledge(offset);
+                    if (!commitOffset.HasValue)
+                        return;
+
+                    // Preserve for any retry — cleared only after a successful commit or
+                    // when a commit is intentionally skipped (revocation/shutdown).
+                    cachedCommitOffset = commitOffset;
+
+                    // Early-exit: if this partition has been revoked since the message was
+                    // dequeued, the rebalance handler will have removed or replaced the tracker
+                    // in _partitionTrackers. Attempting a Commit would throw; skip it — Kafka
+                    // will redeliver the messages to the new owner.
+                    if (!_partitionTrackers.TryGetValue(tp, out var currentTracker)
+                        || !ReferenceEquals(currentTracker, capturedTracker))
                     {
+                        cachedCommitOffset = null; // partition is gone; no future retry makes sense
+                        return;
+                    }
+
+                    // Serialize commits per partition: only one Commit() in flight at a time.
+                    // This prevents a slower low-offset commit from arriving at the broker AFTER
+                    // a faster high-offset commit and regressing the cursor backwards.
+                    // GetOrAdd is a safety-net for the test/IConsumer path where rebalance handlers
+                    // don't pre-populate the dict; in production the assignment handler always
+                    // initializes the lock before the first message is produced to the channel.
+                    var commitLock = _partitionCommitLocks.GetOrAdd(tp, _ => new SemaphoreSlim(1, 1));
+                    await commitLock.WaitAsync(ct);
+                    try
+                    {
+                        // Re-verify after acquiring the lock: if another concurrent ack already
+                        // committed a higher offset while we were waiting, our commit is redundant.
+                        long prevMax = _partitionMaxCommitted.GetOrAdd(tp, _ => NoCommitsYet);
+                        if (commitOffset.Value <= prevMax)
+                        {
+                            cachedCommitOffset = null; // superseded by a concurrent higher ack
+                            return;
+                        }
+
+                        // Advance the high-water mark before issuing the commit so that
+                        // concurrent waiters see the updated value immediately.
+                        _partitionMaxCommitted[tp] = commitOffset.Value;
                         try
                         {
-                            var tpo = new TopicPartitionOffset(tp, new Offset(commitOffset.Value));
-                            _consumer.StoreOffset(tpo);
-                            _consumer.Commit(new[] { tpo });
+                            // Commit explicit offsets directly to the broker.
+                            // StoreOffset is intentionally omitted: Commit(IEnumerable<TopicPartitionOffset>)
+                            // bypasses the local offset store and pushes the commit synchronously,
+                            // so a preceding StoreOffset call would be redundant.
+                            _consumer.Commit(new[] { new TopicPartitionOffset(tp, new Offset(commitOffset.Value)) });
+                            cachedCommitOffset = null; // committed successfully; clear cache
                         }
                         catch (KafkaException)
+                            when (!_partitionTrackers.TryGetValue(tp, out var t2)
+                                  || !ReferenceEquals(t2, capturedTracker))
                         {
-                            // The partition was revoked or rebalanced before the commit
-                            // could be persisted. Kafka will redeliver these messages to
-                            // the new owner — safe to discard this exception.
+                            // TOCTOU race: partition was revoked between the check above and the
+                            // Commit call. Kafka will redeliver to the new owner — safe to discard.
+                            // Do NOT write prevMax back: the assignment handler for a rapid
+                            // re-assignment of the same partition may have already reset the entry
+                            // to NoCommitsYet. Overwriting it with prevMax would block the first
+                            // commit of the new assignment. TryRemove is safe and idempotent —
+                            // the next GetOrAdd will recreate the entry with NoCommitsYet.
+                            _partitionMaxCommitted.TryRemove(tp, out _);
+                            cachedCommitOffset = null;
+                        }
+                        catch (ObjectDisposedException)
+                        {
+                            // The consumer was closed (CloseAsync/Dispose) before this
+                            // ack delegate fired. Treat as a graceful shutdown — Kafka
+                            // will redeliver uncommitted offsets after restart.
+                            _partitionMaxCommitted[tp] = prevMax; // roll back to ensure uncommitted offset is reprocessed after restart
+                            cachedCommitOffset = null;
+                        }
+                        catch (InvalidOperationException) when (_closed)
+                        {
+                            // Consumer entered an invalid state during shutdown.
+                            // Same treatment as ObjectDisposedException above.
+                            _partitionMaxCommitted[tp] = prevMax; // roll back to ensure uncommitted offset is reprocessed after restart
+                            cachedCommitOffset = null;
+                        }
+                        // All other exceptions (broker unavailable, authorization failure,
+                        // timeout, etc.) propagate to the caller; _partitionMaxCommitted is
+                        // rolled back and cachedCommitOffset remains set so the caller can
+                        // retry by calling AcknowledgeAsync() again.
+                        catch
+                        {
+                            _partitionMaxCommitted[tp] = prevMax; // roll back to allow retry with correct offset
+                            throw;
                         }
                     }
-                    return Task.CompletedTask;
+                    finally
+                    {
+                        commitLock.Release();
+                    }
                 });
         }
 
@@ -402,5 +608,83 @@ namespace Take.Elephant.Kafka
         {
             return Deserializers.Utf8.Deserialize(data, isNull, context);
         }
+    }
+
+    /// <summary>
+    /// Type-safe factory for creating <see cref="KafkaReceiverQueue{T}"/> instances.
+    /// Returns the narrowest interface matching the requested <see cref="KafkaAckMode"/>,
+    /// turning accidental DI-container misregistration of a non-Eager queue under the legacy
+    /// <see cref="IKafkaReceiverQueue{T}"/> contract into a <b>compile-time error</b>.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Because <see cref="IKafkaAckableReceiverQueue{T}"/> is intentionally <b>not</b> derived
+    /// from <see cref="IKafkaReceiverQueue{T}"/>, the following is a compile error:
+    /// </para>
+    /// <code>
+    /// // CS0266 — cannot implicitly convert IKafkaAckableReceiverQueue&lt;T&gt; to IKafkaReceiverQueue&lt;T&gt;
+    /// IKafkaReceiverQueue&lt;Order&gt; q = KafkaReceiverQueue.CreateOnSuccess&lt;Order&gt;(…);
+    /// </code>
+    /// <para>
+    /// Compare with <c>new KafkaReceiverQueue&lt;Order&gt;(…, KafkaAckMode.OnSuccess)</c>, which
+    /// compiles fine but throws <see cref="InvalidOperationException"/> at runtime when the
+    /// wrong Dequeue* family is called.
+    /// </para>
+    /// </remarks>
+    public static class KafkaReceiverQueue
+    {
+        // ── Eager (auto-commit) ──────────────────────────────────────────────
+
+        /// <summary>
+        /// Creates a queue in <see cref="KafkaAckMode.Eager"/> mode (auto-commit).
+        /// </summary>
+        /// <returns><see cref="IKafkaReceiverQueue{T}"/> — the non-ackable interface.</returns>
+        public static IKafkaReceiverQueue<T> CreateEager<T>(
+            string bootstrapServers, string topic, string groupId,
+            ISerializer<T> serializer, IDeserializer<string> deserializer = null)
+            => new KafkaReceiverQueue<T>(bootstrapServers, topic, groupId, serializer, deserializer, KafkaAckMode.Eager);
+
+        /// <inheritdoc cref="CreateEager{T}(string,string,string,ISerializer{T},IDeserializer{string})"/>
+        public static IKafkaReceiverQueue<T> CreateEager<T>(
+            ConsumerConfig config, string topic,
+            ISerializer<T> serializer, IDeserializer<string> deserializer = null)
+            => new KafkaReceiverQueue<T>(config, topic, serializer, deserializer, KafkaAckMode.Eager);
+
+        // ── OnSuccess ────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Creates a queue in <see cref="KafkaAckMode.OnSuccess"/> mode.
+        /// The offset is committed only after the caller invokes
+        /// <see cref="KafkaAckableMessage{T}.AcknowledgeAsync"/>.
+        /// </summary>
+        /// <returns><see cref="IKafkaAckableReceiverQueue{T}"/> — the ackable interface.</returns>
+        public static IKafkaAckableReceiverQueue<T> CreateOnSuccess<T>(
+            string bootstrapServers, string topic, string groupId,
+            ISerializer<T> serializer, IDeserializer<string> deserializer = null)
+            => new KafkaReceiverQueue<T>(bootstrapServers, topic, groupId, serializer, deserializer, KafkaAckMode.OnSuccess);
+
+        /// <inheritdoc cref="CreateOnSuccess{T}(string,string,string,ISerializer{T},IDeserializer{string})"/>
+        public static IKafkaAckableReceiverQueue<T> CreateOnSuccess<T>(
+            ConsumerConfig config, string topic,
+            ISerializer<T> serializer, IDeserializer<string> deserializer = null)
+            => new KafkaReceiverQueue<T>(config, topic, serializer, deserializer, KafkaAckMode.OnSuccess);
+
+        // ── Manual ───────────────────────────────────────────────────────────
+
+        /// <summary>
+        /// Creates a queue in <see cref="KafkaAckMode.Manual"/> mode.
+        /// Acknowledgement timing is fully application-controlled.
+        /// </summary>
+        /// <returns><see cref="IKafkaAckableReceiverQueue{T}"/> — the ackable interface.</returns>
+        public static IKafkaAckableReceiverQueue<T> CreateManual<T>(
+            string bootstrapServers, string topic, string groupId,
+            ISerializer<T> serializer, IDeserializer<string> deserializer = null)
+            => new KafkaReceiverQueue<T>(bootstrapServers, topic, groupId, serializer, deserializer, KafkaAckMode.Manual);
+
+        /// <inheritdoc cref="CreateManual{T}(string,string,string,ISerializer{T},IDeserializer{string})"/>
+        public static IKafkaAckableReceiverQueue<T> CreateManual<T>(
+            ConsumerConfig config, string topic,
+            ISerializer<T> serializer, IDeserializer<string> deserializer = null)
+            => new KafkaReceiverQueue<T>(config, topic, serializer, deserializer, KafkaAckMode.Manual);
     }
 }

--- a/src/Take.Elephant.Kafka/KafkaReceiverQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaReceiverQueue.cs
@@ -32,7 +32,7 @@ namespace Take.Elephant.Kafka
         private SemaphoreSlim _consumerStartSemaphore;
         private CancellationTokenSource _cts;
         private Channel<(T Item, Headers KafkaHeaders)> _channel;
-        private Channel<(T Item, Headers KafkaHeaders, TopicPartition Partition, long Offset, PartitionCommitTracker Tracker)> _ackableChannel;
+        private Channel<(T Item, Headers KafkaHeaders, TopicPartition Partition, long Offset, PartitionCommitTracker Tracker, long Epoch)> _ackableChannel;
         private Task _consumerTask;
         private volatile bool _closed;
 
@@ -184,7 +184,7 @@ namespace Take.Elephant.Kafka
                 _partitionTrackers = partitionTrackers ?? new ConcurrentDictionary<TopicPartition, PartitionCommitTracker>();
                 _partitionCommitLocks = partitionCommitLocks ?? new ConcurrentDictionary<TopicPartition, SemaphoreSlim>();
                 _partitionMaxCommitted = partitionMaxCommitted ?? new ConcurrentDictionary<TopicPartition, long>();
-                _ackableChannel = Channel.CreateBounded<(T, Headers, TopicPartition, long, PartitionCommitTracker)>(1);
+                _ackableChannel = Channel.CreateBounded<(T, Headers, TopicPartition, long, PartitionCommitTracker, long)>(1);
             }
         }
 
@@ -276,13 +276,15 @@ namespace Take.Elephant.Kafka
         }
 
         private KafkaAckableMessage<T> BuildAckableMessage(
-            (T Item, Headers KafkaHeaders, TopicPartition Partition, long Offset, PartitionCommitTracker Tracker) entry)
+            (T Item, Headers KafkaHeaders, TopicPartition Partition, long Offset, PartitionCommitTracker Tracker, long Epoch) entry)
         {
             var tp = entry.Partition;
             var offset = entry.Offset;
-            // Capture tracker at dequeue time; a post-dequeue rebalance gets a new tracker instance,
-            // so stale ack delegates reference the old one and get rejected by the revocation check.
+            // Capture tracker and epoch at dequeue time; a post-dequeue rebalance gets a new tracker
+            // instance, and a backward seek increments the epoch, so stale ack delegates are rejected
+            // both by the revocation check and by the epoch mismatch guard in Acknowledge().
             var capturedTracker = entry.Tracker;
+            var capturedEpoch = entry.Epoch;
             var headers = KafkaHeadersConverter.ToReadOnlyDictionary(entry.KafkaHeaders);
 
             // Cached commit offset: reused on retry if a preceding Commit() threw,
@@ -298,7 +300,7 @@ namespace Take.Elephant.Kafka
                 async ct =>
                 {
                     // Use cached value from a failed retry, or compute fresh via tracker.
-                    var commitOffset = cachedCommitOffset ?? capturedTracker.Acknowledge(offset);
+                    var commitOffset = cachedCommitOffset ?? capturedTracker.Acknowledge(offset, capturedEpoch);
                     if (!commitOffset.HasValue)
                         return;
 
@@ -459,7 +461,7 @@ namespace Take.Elephant.Kafka
                         // Track before deserialize: if Deserialize throws for offset N, the tracker
                         // would never see N, allowing the next offset to bootstrap/advance past it
                         // and silently skip the poison record on commit.
-                        tracker.Track(offset);
+                        var epoch = tracker.Track(offset);
                         T resultValue;
                         try
                         {
@@ -470,12 +472,12 @@ namespace Take.Elephant.Kafka
                             // Auto-advance HWM past the poison record so the tracker never blocks
                             // future commits waiting for an offset that will never be acked.
                             // The exception still propagates to the ConsumerFailed handler.
-                            tracker.Acknowledge(offset);
+                            tracker.Acknowledge(offset, epoch);
                             throw;
                         }
                         // Track before channel write: no ack can race ahead of its Track() call.
                         await _ackableChannel.Writer.WriteAsync(
-                            (resultValue, result.Message.Headers, tp, offset, tracker),
+                            (resultValue, result.Message.Headers, tp, offset, tracker, epoch),
                             cancellationToken);
                         // Clear the state-machine field so a revoked tracker becomes GC-eligible
                         // before the loop blocks again at _consumer.Consume().

--- a/src/Take.Elephant.Kafka/KafkaReceiverQueue.cs
+++ b/src/Take.Elephant.Kafka/KafkaReceiverQueue.cs
@@ -12,88 +12,47 @@ using System.Threading.Tasks;
 namespace Take.Elephant.Kafka
 {
     /// <summary>
-    /// Kafka receiver queue that supports three acknowledgement modes:
-    /// <list type="bullet">
-    ///   <item><see cref="KafkaAckMode.Eager"/> — legacy default: auto-commit managed by Confluent client.</item>
-    ///   <item><see cref="KafkaAckMode.OnSuccess"/> — offset committed only after the caller invokes <see cref="KafkaAckableMessage{T}.AcknowledgeAsync"/>.</item>
-    ///   <item><see cref="KafkaAckMode.Manual"/> — same as OnSuccess but acknowledgement timing is fully application-controlled.</item>
-    /// </list>
+    /// Kafka receiver queue with three offset-commit modes: <see cref="KafkaAckMode.Eager"/> (auto-commit),
+    /// <see cref="KafkaAckMode.OnSuccess"/>, and <see cref="KafkaAckMode.Manual"/>.
+    /// Prefer the <see cref="KafkaReceiverQueue"/> static factory for type-safe construction.
     /// </summary>
-    /// <remarks>
-    /// This class implements both <see cref="IKafkaReceiverQueue{T}"/> and
-    /// <see cref="IKafkaAckableReceiverQueue{T}"/>. The two interfaces are mode-exclusive;
-    /// calling the wrong family of Dequeue methods throws <see cref="InvalidOperationException"/>.
-    /// <para>
-    /// <b>Preferred construction:</b> use the <see cref="KafkaReceiverQueue"/> static factory class
-    /// instead of calling <c>new KafkaReceiverQueue&lt;T&gt;(...)</c> directly. The factory methods
-    /// return the narrowest interface that matches the requested mode, turning accidental
-    /// DI-container misregistration into a compile-time error rather than a runtime failure.
-    /// </para>
-    /// <code>
-    /// // Eager (auto-commit) — returns IKafkaReceiverQueue&lt;T&gt;
-    /// IKafkaReceiverQueue&lt;Order&gt; q = KafkaReceiverQueue.CreateEager&lt;Order&gt;(config, topic, s);
-    ///
-    /// // OnSuccess / Manual — returns IKafkaAckableReceiverQueue&lt;T&gt;
-    /// IKafkaAckableReceiverQueue&lt;Order&gt; q = KafkaReceiverQueue.CreateOnSuccess&lt;Order&gt;(config, topic, s);
-    ///
-    /// // The following is a COMPILE ERROR — compile-time protection against misregistration:
-    /// // IKafkaReceiverQueue&lt;Order&gt; q = KafkaReceiverQueue.CreateOnSuccess&lt;Order&gt;(…);
-    /// </code>
-    /// </remarks>
     public class KafkaReceiverQueue<T> : IKafkaAckableReceiverQueue<T>, IKafkaReceiverQueue<T>, IOpenable, ICloseable, IDisposable
     {
         private IConsumer<Ignore, string> _consumer;
         private ISerializer<T> _serializer;
         private KafkaAckMode _ackMode;
-        // Per-partition commit trackers — one instance per assigned partition (OnSuccess/Manual only)
         private ConcurrentDictionary<TopicPartition, PartitionCommitTracker> _partitionTrackers;
-        // Per-partition commit serialization (OnSuccess/Manual only).
-        // Ensures only one Commit() call is in flight per partition at a time, preventing
-        // a slower lower-offset commit from moving the broker cursor backwards when
-        // multiple messages are acknowledged concurrently.
+        // One Commit() in flight per partition — prevents cursor regression from out-of-order async acks.
         private ConcurrentDictionary<TopicPartition, SemaphoreSlim> _partitionCommitLocks;
-        // Per-partition highest offset value we have committed so far (OnSuccess/Manual only).
-        // Used inside the per-partition commit lock to skip commits that are no longer the
-        // highest — guards against a slow Commit(N) arriving after a fast Commit(M > N) and
-        // regressing the broker cursor.
+        // Highest offset committed per partition; monotonic guard inside the per-partition lock.
         private ConcurrentDictionary<TopicPartition, long> _partitionMaxCommitted;
-        // Sentinel that represents "no broker commit has been issued for this partition yet."
         private const long NoCommitsYet = long.MinValue;
         private SemaphoreSlim _consumerStartSemaphore;
         private CancellationTokenSource _cts;
-        // Eager channel: (Item, Headers)
         private Channel<(T Item, Headers KafkaHeaders)> _channel;
-        // Ackable channel: includes partition/offset and the per-partition tracker snapshot
         private Channel<(T Item, Headers KafkaHeaders, TopicPartition Partition, long Offset, PartitionCommitTracker Tracker)> _ackableChannel;
         private Task _consumerTask;
         private volatile bool _closed;
 
-        // ── Binary-compatible overload: preserves the original 5-param CLR signature.
-        // Assemblies compiled against the previous NuGet version of this library call
-        // the constructor without ackMode. This explicit overload keeps those binaries
-        // working after the package upgrade (defaults to Eager auto-commit).
+        // Binary-compatible: preserves existing CLR signatures; defaults to Eager.
         public KafkaReceiverQueue(string bootstrapServers, string topic, string groupId, ISerializer<T> serializer, IDeserializer<string> deserializer = null)
             : this(bootstrapServers, topic, groupId, serializer, deserializer, KafkaAckMode.Eager)
         {
         }
 
-        // New overload that accepts an explicit ackMode.
-        // IDeserializer<string> is required (not optional) to avoid CLR ambiguity with the
-        // binary-compatible 5-param overload above.
+        // IDeserializer<string> is required (not optional) to avoid CLR ambiguity with the 5-param overload above.
         public KafkaReceiverQueue(string bootstrapServers, string topic, string groupId, ISerializer<T> serializer, IDeserializer<string> deserializer, KafkaAckMode ackMode)
             : this(new ConsumerConfig() { BootstrapServers = bootstrapServers, GroupId = groupId }, topic, serializer, deserializer, ackMode)
         {
         }
 
-        // ── Binary-compatible overload: preserves the original 4-param CLR signature.
+        // Binary-compatible: preserves existing CLR signatures; defaults to Eager.
         public KafkaReceiverQueue(ConsumerConfig consumerConfig, string topic, ISerializer<T> serializer, IDeserializer<string> deserializer = null)
             : this(consumerConfig, topic, serializer, deserializer, KafkaAckMode.Eager)
         {
         }
 
-        // New overload that accepts an explicit ackMode.
-        // IDeserializer<string> is required (not optional) to avoid CLR ambiguity with the
-        // binary-compatible 4-param overload above.
+        // IDeserializer<string> is required (not optional) to avoid CLR ambiguity with the 4-param overload above.
         public KafkaReceiverQueue(
             ConsumerConfig consumerConfig,
             string topic,
@@ -106,14 +65,13 @@ namespace Take.Elephant.Kafka
             ConcurrentDictionary<TopicPartition, long> partitionMaxCommitted = null;
             if (ackMode != KafkaAckMode.Eager)
             {
-                // Disable auto-commit so we control offset stores
+                // Disable auto-commit; commits are driven by AcknowledgeAsync.
                 consumerConfig = new ConsumerConfig(consumerConfig)
                 {
                     EnableAutoCommit = false,
                     EnableAutoOffsetStore = false,
                 };
-                // Create the dictionaries before wiring the handlers so the closures
-                // capture the same references that Initialize() will store.
+                // Initialize per-partition state before wiring rebalance handlers.
                 partitionTrackers = new ConcurrentDictionary<TopicPartition, PartitionCommitTracker>();
                 partitionCommitLocks = new ConcurrentDictionary<TopicPartition, SemaphoreSlim>();
                 partitionMaxCommitted = new ConcurrentDictionary<TopicPartition, long>();
@@ -124,10 +82,6 @@ namespace Take.Elephant.Kafka
 
             if (partitionTrackers != null)
             {
-                // On assignment: install a fresh tracker + commit state for each new partition
-                // so that state from any previous assignment cannot block future commits.
-                // On revoke/lost: remove all per-partition state; the partition is no longer
-                // ours, so Kafka will redeliver to the new owner.
                 builder = builder
                     .SetPartitionsAssignedHandler((c, partitions) =>
                     {
@@ -144,10 +98,9 @@ namespace Take.Elephant.Kafka
                         {
                             var tp = tpo.TopicPartition;
                             partitionTrackers.TryRemove(tp, out _);
-                            // The SemaphoreSlim is intentionally NOT disposed here: in-flight
-                            // ack delegates may still be waiting on it when revoke fires, and
-                            // disposing a SemaphoreSlim with waiters throws ObjectDisposedException.
-                            // The GC collects the instance once all waiters release.
+                            // SemaphoreSlim is NOT disposed here: in-flight ack delegates may still
+                            // be waiting on it when revoke fires, and disposing with waiters throws
+                            // ObjectDisposedException. The GC collects the instance once released.
                             partitionCommitLocks.TryRemove(tp, out _);
                             partitionMaxCommitted.TryRemove(tp, out _);
                         }
@@ -158,7 +111,7 @@ namespace Take.Elephant.Kafka
                         {
                             var tp = tpo.TopicPartition;
                             partitionTrackers.TryRemove(tp, out _);
-                            partitionCommitLocks.TryRemove(tp, out _); // same note as above
+                            partitionCommitLocks.TryRemove(tp, out _);
                             partitionMaxCommitted.TryRemove(tp, out _);
                         }
                     });
@@ -167,36 +120,18 @@ namespace Take.Elephant.Kafka
             Initialize(builder.Build(), serializer, topic, ackMode, partitionTrackers, partitionCommitLocks, partitionMaxCommitted);
         }
 
-        /// <summary>
-        /// Initializes a new instance using an already-built <see cref="IConsumer{TKey, TValue}"/>.
-        /// Only <see cref="KafkaAckMode.Eager"/> is accepted; passing any other mode throws
-        /// <see cref="ArgumentException"/> because a consumer injected from outside cannot be
-        /// guaranteed to have <c>EnableAutoCommit = false</c> and <c>EnableAutoOffsetStore = false</c>,
-        /// which are required for at-least-once delivery.
-        /// For <see cref="KafkaAckMode.OnSuccess"/> or <see cref="KafkaAckMode.Manual"/>, use the
-        /// constructor that accepts <see cref="Confluent.Kafka.ConsumerConfig"/>.
-        /// </summary>
-        /// <remarks>
-        /// Binary-compatible overload. Calls <see cref="KafkaReceiverQueue{T}(IConsumer{Ignore,string},ISerializer{T},string,KafkaAckMode)"/>
-        /// with <see cref="KafkaAckMode.Eager"/>.
-        /// </remarks>
+        // Binary-compatible: preserves existing CLR signatures.
         public KafkaReceiverQueue(IConsumer<Ignore, string> consumer, ISerializer<T> serializer, string topic)
             : this(consumer, serializer, topic, KafkaAckMode.Eager)
         {
         }
 
         /// <summary>
-        /// Initializes a new instance using an already-built <see cref="IConsumer{TKey, TValue}"/>.
-        /// Only <see cref="KafkaAckMode.Eager"/> is accepted; passing any other mode throws
-        /// <see cref="ArgumentException"/> because a consumer injected from outside cannot be
-        /// guaranteed to have <c>EnableAutoCommit = false</c> and <c>EnableAutoOffsetStore = false</c>,
-        /// which are required for at-least-once delivery.
-        /// For <see cref="KafkaAckMode.OnSuccess"/> or <see cref="KafkaAckMode.Manual"/>, use the
-        /// constructor that accepts <see cref="Confluent.Kafka.ConsumerConfig"/>.
+        /// Initializes with an already-built <see cref="IConsumer{TKey, TValue}"/>.
+        /// Only <see cref="KafkaAckMode.Eager"/> is accepted; non-Eager requires
+        /// <c>EnableAutoCommit = false</c> which cannot be guaranteed on an injected consumer.
         /// </summary>
-        /// <exception cref="ArgumentException">
-        /// Thrown when <paramref name="ackMode"/> is not <see cref="KafkaAckMode.Eager"/>.
-        /// </exception>
+        /// <exception cref="ArgumentException">Thrown when <paramref name="ackMode"/> is not Eager.</exception>
         public KafkaReceiverQueue(IConsumer<Ignore, string> consumer, ISerializer<T> serializer, string topic,
             KafkaAckMode ackMode = KafkaAckMode.Eager)
         {
@@ -211,12 +146,7 @@ namespace Take.Elephant.Kafka
             Initialize(consumer, serializer, topic, ackMode, null, null, null);
         }
 
-        /// <summary>
-        /// Internal constructor used exclusively by unit tests that need to inject a mocked consumer
-        /// with a non-Eager <see cref="KafkaAckMode"/>.
-        /// The caller must ensure the mock is configured with <c>EnableAutoCommit = false</c> and
-        /// <c>EnableAutoOffsetStore = false</c> to preserve the at-least-once guarantee.
-        /// </summary>
+        // Test seam: allows injecting a mocked consumer with non-Eager mode.
         internal KafkaReceiverQueue(IConsumer<Ignore, string> consumer, ISerializer<T> serializer, string topic,
             KafkaAckMode ackMode, ConcurrentDictionary<TopicPartition, PartitionCommitTracker> partitionTrackers)
         {
@@ -247,8 +177,6 @@ namespace Take.Elephant.Kafka
             }
             else
             {
-                // Use the pre-created dictionaries (which already have rebalance handlers
-                // wired via ConsumerBuilder) or create fresh ones for the IConsumer path.
                 _partitionTrackers = partitionTrackers ?? new ConcurrentDictionary<TopicPartition, PartitionCommitTracker>();
                 _partitionCommitLocks = partitionCommitLocks ?? new ConcurrentDictionary<TopicPartition, SemaphoreSlim>();
                 _partitionMaxCommitted = partitionMaxCommitted ?? new ConcurrentDictionary<TopicPartition, long>();
@@ -318,8 +246,6 @@ namespace Take.Elephant.Kafka
             return KafkaHeadersConverter.BuildConsumedMessage(item.Item, item.KafkaHeaders);
         }
 
-        // ---- IKafkaAckableReceiverQueue<T> ----
-
         public async Task<KafkaAckableMessage<T>> DequeueAckableAsync(CancellationToken cancellationToken)
         {
             if (_ackMode == KafkaAckMode.Eager)
@@ -350,18 +276,13 @@ namespace Take.Elephant.Kafka
         {
             var tp = entry.Partition;
             var offset = entry.Offset;
-            // Capture the tracker instance at message-creation time (not the field).
-            // If a rebalance happens before AcknowledgeAsync is called, the delegate
-            // still references the OLD tracker for this partition; the new assignment
-            // gets a brand-new tracker instance. Any commit attempted on the old
-            // partition after revocation throws a KafkaException, which we catch below.
+            // Capture tracker at dequeue time; a post-dequeue rebalance gets a new tracker instance,
+            // so stale ack delegates reference the old one and get rejected by the revocation check.
             var capturedTracker = entry.Tracker;
             var headers = KafkaHeadersConverter.ToReadOnlyDictionary(entry.KafkaHeaders);
 
-            // Cached commit offset: set the first time Acknowledge() computes the HWM;
-            // reused on retry if the preceding Commit() call threw an exception.
-            // The tracker's HWM has already advanced at that point, so re-calling
-            // capturedTracker.Acknowledge(offset) would return null on a retry.
+            // Cached commit offset: reused on retry if a preceding Commit() threw,
+            // since the tracker's HWM has already advanced and would return null on retry.
             long? cachedCommitOffset = null;
 
             return new KafkaAckableMessage<T>(
@@ -372,93 +293,72 @@ namespace Take.Elephant.Kafka
                 offset,
                 async ct =>
                 {
-                    // Use cached value from a previous failed attempt, or compute fresh via tracker.
+                    // Use cached value from a failed retry, or compute fresh via tracker.
                     var commitOffset = cachedCommitOffset ?? capturedTracker.Acknowledge(offset);
                     if (!commitOffset.HasValue)
                         return;
 
-                    // Preserve for any retry — cleared only after a successful commit or
-                    // when a commit is intentionally skipped (revocation/shutdown).
                     cachedCommitOffset = commitOffset;
 
-                    // Early-exit: if this partition has been revoked since the message was
-                    // dequeued, the rebalance handler will have removed or replaced the tracker
-                    // in _partitionTrackers. Attempting a Commit would throw; skip it — Kafka
-                    // will redeliver the messages to the new owner.
+                    // Partition revoked since dequeue: new owner will redeliver.
                     if (!_partitionTrackers.TryGetValue(tp, out var currentTracker)
                         || !ReferenceEquals(currentTracker, capturedTracker))
                     {
-                        cachedCommitOffset = null; // partition is gone; no future retry makes sense
+                        cachedCommitOffset = null;
                         return;
                     }
 
-                    // Serialize commits per partition: only one Commit() in flight at a time.
-                    // This prevents a slower low-offset commit from arriving at the broker AFTER
-                    // a faster high-offset commit and regressing the cursor backwards.
-                    // GetOrAdd is a safety-net for the test/IConsumer path where rebalance handlers
-                    // don't pre-populate the dict; in production the assignment handler always
-                    // initializes the lock before the first message is produced to the channel.
+                    // One Commit() per partition at a time: prevents a slow low-offset commit
+                    // from regressing the broker cursor after a faster high-offset commit.
+                    // GetOrAdd: safety-net for the test/IConsumer path where assignment handlers
+                    // don't pre-populate the dict.
                     var commitLock = _partitionCommitLocks.GetOrAdd(tp, _ => new SemaphoreSlim(1, 1));
                     await commitLock.WaitAsync(ct);
                     try
                     {
-                        // Re-verify after acquiring the lock: if another concurrent ack already
-                        // committed a higher offset while we were waiting, our commit is redundant.
+                        // If a concurrent ack already committed a higher offset, skip.
                         long prevMax = _partitionMaxCommitted.GetOrAdd(tp, _ => NoCommitsYet);
                         if (commitOffset.Value <= prevMax)
                         {
-                            cachedCommitOffset = null; // superseded by a concurrent higher ack
+                            cachedCommitOffset = null;
                             return;
                         }
 
-                        // Advance the high-water mark before issuing the commit so that
-                        // concurrent waiters see the updated value immediately.
+                        // Update HWM before committing so concurrent waiters see it immediately.
                         _partitionMaxCommitted[tp] = commitOffset.Value;
                         try
                         {
-                            // Commit explicit offsets directly to the broker.
-                            // StoreOffset is intentionally omitted: Commit(IEnumerable<TopicPartitionOffset>)
-                            // bypasses the local offset store and pushes the commit synchronously,
-                            // so a preceding StoreOffset call would be redundant.
+                            // Bypass local offset store; push commit synchronously to the broker.
                             _consumer.Commit(new[] { new TopicPartitionOffset(tp, new Offset(commitOffset.Value)) });
-                            cachedCommitOffset = null; // committed successfully; clear cache
+                            cachedCommitOffset = null;
                         }
                         catch (KafkaException)
                             when (!_partitionTrackers.TryGetValue(tp, out var t2)
                                   || !ReferenceEquals(t2, capturedTracker))
                         {
-                            // TOCTOU race: partition was revoked between the check above and the
-                            // Commit call. Kafka will redeliver to the new owner — safe to discard.
-                            // Do NOT write prevMax back: the assignment handler for a rapid
-                            // re-assignment of the same partition may have already reset the entry
-                            // to NoCommitsYet. Overwriting it with prevMax would block the first
-                            // commit of the new assignment. TryRemove is safe and idempotent —
-                            // the next GetOrAdd will recreate the entry with NoCommitsYet.
+                            // TOCTOU race: partition revoked between revocation-check and Commit.
+                            // Kafka redelivers to new owner. TryRemove prevents stale prevMax from
+                            // blocking the first commit of a rapid re-assignment.
                             _partitionMaxCommitted.TryRemove(tp, out _);
                             cachedCommitOffset = null;
                         }
                         catch (ObjectDisposedException)
                         {
-                            // The consumer was closed (CloseAsync/Dispose) before this
-                            // ack delegate fired. Treat as a graceful shutdown — Kafka
-                            // will redeliver uncommitted offsets after restart.
-                            _partitionMaxCommitted[tp] = prevMax; // roll back to ensure uncommitted offset is reprocessed after restart
+                            // Consumer closed before ack fired; Kafka redelivers after restart.
+                            _partitionMaxCommitted[tp] = prevMax;
                             cachedCommitOffset = null;
                         }
                         catch (InvalidOperationException) when (_closed)
                         {
-                            // Consumer entered an invalid state during shutdown.
-                            // Same treatment as ObjectDisposedException above.
-                            _partitionMaxCommitted[tp] = prevMax; // roll back to ensure uncommitted offset is reprocessed after restart
+                            // Consumer in invalid state during shutdown; same as ObjectDisposedException.
+                            _partitionMaxCommitted[tp] = prevMax;
                             cachedCommitOffset = null;
                         }
-                        // All other exceptions (broker unavailable, authorization failure,
-                        // timeout, etc.) propagate to the caller; _partitionMaxCommitted is
-                        // rolled back and cachedCommitOffset remains set so the caller can
-                        // retry by calling AcknowledgeAsync() again.
+                        // Other exceptions (broker unavailable, timeout, etc.) propagate to caller;
+                        // prevMax is rolled back and cachedCommitOffset preserved so the caller can retry.
                         catch
                         {
-                            _partitionMaxCommitted[tp] = prevMax; // roll back to allow retry with correct offset
+                            _partitionMaxCommitted[tp] = prevMax;
                             throw;
                         }
                     }
@@ -551,9 +451,7 @@ namespace Take.Elephant.Kafka
                     {
                         var tp = result.TopicPartition;
                         var offset = result.Offset.Value;
-                        // Obtain (or lazily create) the per-partition tracker, then
-                        // record the offset before pushing the message to the channel
-                        // so no ack can race ahead of its Track() call.
+                        // Track before channel write: no ack can race ahead of its Track() call.
                         var tracker = _partitionTrackers.GetOrAdd(tp, _ => new PartitionCommitTracker());
                         tracker.Track(offset);
                         await _ackableChannel.Writer.WriteAsync(
@@ -611,77 +509,36 @@ namespace Take.Elephant.Kafka
     }
 
     /// <summary>
-    /// Type-safe factory for creating <see cref="KafkaReceiverQueue{T}"/> instances.
-    /// Returns the narrowest interface matching the requested <see cref="KafkaAckMode"/>,
-    /// turning accidental DI-container misregistration of a non-Eager queue under the legacy
-    /// <see cref="IKafkaReceiverQueue{T}"/> contract into a <b>compile-time error</b>.
+    /// Type-safe factory for <see cref="KafkaReceiverQueue{T}"/>. Returns the narrowest interface
+    /// for the requested <see cref="KafkaAckMode"/>, making accidental DI misregistration a compile-time error.
     /// </summary>
-    /// <remarks>
-    /// <para>
-    /// Because <see cref="IKafkaAckableReceiverQueue{T}"/> is intentionally <b>not</b> derived
-    /// from <see cref="IKafkaReceiverQueue{T}"/>, the following is a compile error:
-    /// </para>
-    /// <code>
-    /// // CS0266 — cannot implicitly convert IKafkaAckableReceiverQueue&lt;T&gt; to IKafkaReceiverQueue&lt;T&gt;
-    /// IKafkaReceiverQueue&lt;Order&gt; q = KafkaReceiverQueue.CreateOnSuccess&lt;Order&gt;(…);
-    /// </code>
-    /// <para>
-    /// Compare with <c>new KafkaReceiverQueue&lt;Order&gt;(…, KafkaAckMode.OnSuccess)</c>, which
-    /// compiles fine but throws <see cref="InvalidOperationException"/> at runtime when the
-    /// wrong Dequeue* family is called.
-    /// </para>
-    /// </remarks>
     public static class KafkaReceiverQueue
     {
-        // ── Eager (auto-commit) ──────────────────────────────────────────────
-
-        /// <summary>
-        /// Creates a queue in <see cref="KafkaAckMode.Eager"/> mode (auto-commit).
-        /// </summary>
-        /// <returns><see cref="IKafkaReceiverQueue{T}"/> — the non-ackable interface.</returns>
         public static IKafkaReceiverQueue<T> CreateEager<T>(
             string bootstrapServers, string topic, string groupId,
             ISerializer<T> serializer, IDeserializer<string> deserializer = null)
             => new KafkaReceiverQueue<T>(bootstrapServers, topic, groupId, serializer, deserializer, KafkaAckMode.Eager);
 
-        /// <inheritdoc cref="CreateEager{T}(string,string,string,ISerializer{T},IDeserializer{string})"/>
         public static IKafkaReceiverQueue<T> CreateEager<T>(
             ConsumerConfig config, string topic,
             ISerializer<T> serializer, IDeserializer<string> deserializer = null)
             => new KafkaReceiverQueue<T>(config, topic, serializer, deserializer, KafkaAckMode.Eager);
 
-        // ── OnSuccess ────────────────────────────────────────────────────────
-
-        /// <summary>
-        /// Creates a queue in <see cref="KafkaAckMode.OnSuccess"/> mode.
-        /// The offset is committed only after the caller invokes
-        /// <see cref="KafkaAckableMessage{T}.AcknowledgeAsync"/>.
-        /// </summary>
-        /// <returns><see cref="IKafkaAckableReceiverQueue{T}"/> — the ackable interface.</returns>
         public static IKafkaAckableReceiverQueue<T> CreateOnSuccess<T>(
             string bootstrapServers, string topic, string groupId,
             ISerializer<T> serializer, IDeserializer<string> deserializer = null)
             => new KafkaReceiverQueue<T>(bootstrapServers, topic, groupId, serializer, deserializer, KafkaAckMode.OnSuccess);
 
-        /// <inheritdoc cref="CreateOnSuccess{T}(string,string,string,ISerializer{T},IDeserializer{string})"/>
         public static IKafkaAckableReceiverQueue<T> CreateOnSuccess<T>(
             ConsumerConfig config, string topic,
             ISerializer<T> serializer, IDeserializer<string> deserializer = null)
             => new KafkaReceiverQueue<T>(config, topic, serializer, deserializer, KafkaAckMode.OnSuccess);
 
-        // ── Manual ───────────────────────────────────────────────────────────
-
-        /// <summary>
-        /// Creates a queue in <see cref="KafkaAckMode.Manual"/> mode.
-        /// Acknowledgement timing is fully application-controlled.
-        /// </summary>
-        /// <returns><see cref="IKafkaAckableReceiverQueue{T}"/> — the ackable interface.</returns>
         public static IKafkaAckableReceiverQueue<T> CreateManual<T>(
             string bootstrapServers, string topic, string groupId,
             ISerializer<T> serializer, IDeserializer<string> deserializer = null)
             => new KafkaReceiverQueue<T>(bootstrapServers, topic, groupId, serializer, deserializer, KafkaAckMode.Manual);
 
-        /// <inheritdoc cref="CreateManual{T}(string,string,string,ISerializer{T},IDeserializer{string})"/>
         public static IKafkaAckableReceiverQueue<T> CreateManual<T>(
             ConsumerConfig config, string topic,
             ISerializer<T> serializer, IDeserializer<string> deserializer = null)

--- a/src/Take.Elephant.Kafka/PartitionCommitTracker.cs
+++ b/src/Take.Elephant.Kafka/PartitionCommitTracker.cs
@@ -3,73 +3,23 @@ using System.Collections.Generic;
 namespace Take.Elephant.Kafka
 {
     /// <summary>
-    /// Tracks acknowledged offsets for a single Kafka partition and returns the
-    /// highest contiguous offset safe to commit (i.e., all offsets from the last
-    /// committed point up to the returned offset have been acknowledged — no gaps).
-    ///
-    /// Each instance is scoped to one <see cref="Confluent.Kafka.TopicPartition"/>.
-    /// A new instance must be created whenever the partition is (re-)assigned after
-    /// a rebalance so that stale state from a previous assignment cannot block future
-    /// commits. The rebalance handlers in <see cref="KafkaReceiverQueue{T}"/> replace
-    /// the entry in <c>_partitionTrackers</c> with a fresh instance; the old instance
-    /// remains alive as long as in-flight delegates from before the rebalance still
-    /// hold a reference to it. Those delegates may call <see cref="Acknowledge"/> on
-    /// the old instance, advance its HWM, and then attempt a Kafka commit — which will
-    /// throw a <see cref="Confluent.Kafka.KafkaException"/> because the partition is no
-    /// longer owned by this consumer. That exception is caught in the ack delegate and
-    /// discarded; Kafka will redeliver the messages to the new owner.
-    ///
-    /// Algorithm:
-    ///   - <see cref="Track"/> bootstraps the HWM on the first call and handles two
-    ///     classes of intra-assignment offset discontinuity:
-    ///     (a) Backward jumps (offset &lt; last tracked): caused by a manual
-    ///         <c>consumer.Seek()</c> to a prior position. The HWM, acked set, and
-    ///         phantom-gap queue are reset relative to the new position, and a new
-    ///         epoch boundary is recorded so that in-flight delegates from before the
-    ///         seek are discarded by <see cref="Acknowledge"/>.
-    ///     (b) Forward gaps (offset &gt; last tracked + 1): caused by log compaction,
-    ///         aborted transactions, or control records that are never delivered to
-    ///         consumers. These are <b>not</b> treated as resets.
-    ///         If no messages are currently in flight (all prior offsets have been
-    ///         committed), the HWM is advanced in O(1) to skip the gap.
-    ///         Otherwise, the gap is recorded as a <em>phantom range</em>
-    ///         <c>(start, end)</c> in a FIFO queue. During HWM advancement the entire
-    ///         range is skipped in a single O(1) dequeue, regardless of how large the
-    ///         gap is. This avoids the O(gap) per-offset allocation that would be
-    ///         required when pre-populating a sorted set with every phantom offset.
-    ///   - <see cref="Acknowledge"/> adds the offset to the acked set and advances
-    ///     the HWM while the next expected offset is either in the acked set or at the
-    ///     start of a phantom range. Acks for offsets below the current epoch boundary
-    ///     are discarded immediately to prevent stale delegates from causing a memory
-    ///     leak or a spurious commit.
-    ///
-    /// Known limitation: after a backward seek to offset S, in-flight ack delegates
-    /// created before the seek for offsets &gt;= S are not filtered (they share the
-    /// same epoch). In the unlikely scenario where such a stale ack arrives before its
-    /// corresponding replay-ack, it may accelerate the HWM. This is an inherent
-    /// trade-off of single-epoch tracking and is acceptable given that manual seeks are
-    /// rare in production consumers.
-    ///
-    /// Thread-safe.
+    /// Thread-safe HWM (high-water-mark) tracker for a single Kafka partition.
+    /// Returns the next offset to commit only when all offsets from the last commit are contiguous.
+    /// Handles forward gaps (compacted/aborted offsets) via O(1) phantom-range queuing and
+    /// backward seeks via epoch-boundary reset. Scoped to one partition assignment; create a new
+    /// instance on rebalance.
     /// </summary>
     internal sealed class PartitionCommitTracker
     {
         private readonly SortedSet<long> _acked = new SortedSet<long>();
-        // Phantom gap ranges: offsets that were never delivered (compacted / aborted records).
-        // Stored in FIFO order (same order as Track() calls). Each entry is (start, end) inclusive
-        // on both ends. The first entry in the queue is always the next phantom range the HWM will
-        // encounter, which is why a Queue is sufficient — gaps arrive and are consumed in strict order.
+        // FIFO ranges of offsets never delivered (compacted/aborted); consumed in strict order as HWM advances.
         private readonly Queue<(long Start, long End)> _phantomGaps = new Queue<(long, long)>();
         private readonly object _lock = new object();
         private long _lastCommitted = long.MinValue; // uninitialized sentinel
-        private long _lastTracked   = long.MinValue; // last offset seen in Track(); used for discontinuity detection
-        private long _epochStart    = long.MinValue; // lowest valid offset of current epoch; stale acks below this are discarded
+        private long _lastTracked   = long.MinValue; // last offset seen in Track()
+        private long _epochStart    = long.MinValue; // lowest valid offset for current assignment; stale acks below this are discarded
 
-        /// <summary>
-        /// Records that <paramref name="offset"/> was consumed. Must be called before
-        /// the message is dispatched downstream. Bootstraps the HWM on the first call
-        /// so that contiguity is relative to this run's starting offset.
-        /// </summary>
+        /// <summary>Records a consumed offset. Must be called before dispatching downstream.</summary>
         public void Track(long offset)
         {
             lock (_lock)
@@ -87,12 +37,8 @@ namespace Take.Elephant.Kafka
                 {
                     if (offset < _lastTracked)
                     {
-                        // ── Backward jump: manual consumer.Seek() to a prior position ──────────
-                        // The offsets between _lastTracked and offset will never arrive again.
-                        // Reset HWM, the acked set, and the phantom-gap queue. Advance the epoch
-                        // boundary so that any Acknowledge() calls still in flight for the old
-                        // positions are silently discarded, preventing memory leaks and spurious
-                        // commits.
+                        // Backward seek: reset HWM, acked set, and phantom-gap queue.
+                        // Advance epoch boundary to discard in-flight acks from the old position.
                         _lastCommitted = offset - 1;
                         _acked.Clear();
                         _phantomGaps.Clear();
@@ -100,21 +46,13 @@ namespace Take.Elephant.Kafka
                     }
                     else if (_acked.Count == 0 && _lastCommitted == _lastTracked)
                     {
-                        // ── Forward gap, no messages in flight ────────────────────────────────
-                        // All previously tracked offsets have already been acked and committed
-                        // (_lastCommitted == _lastTracked). The gap offsets (compacted, aborted
-                        // transactions, control records) will never be delivered, so there is
-                        // nothing to wait for. Advance _lastCommitted directly in O(1).
+                        // Forward gap, no in-flight messages: advance HWM directly in O(1).
                         _lastCommitted = offset - 1;
                     }
                     else
                     {
-                        // ── Forward gap with in-flight messages ───────────────────────────────
-                        // Some earlier offsets are still being processed concurrently.
-                        // Record the phantom range in O(1). The HWM advancement loop in
-                        // Acknowledge() will skip the entire range with a single Dequeue()
-                        // call when it reaches the start of the gap, avoiding any per-offset
-                        // allocation regardless of how large the gap is.
+                        // Forward gap with in-flight messages: record phantom range in O(1).
+                        // Acknowledge() skips the entire range in a single Dequeue(), avoiding per-offset allocations.
                         _phantomGaps.Enqueue((_lastTracked + 1, offset - 1));
                     }
                 }
@@ -124,10 +62,8 @@ namespace Take.Elephant.Kafka
         }
 
         /// <summary>
-        /// Marks <paramref name="offset"/> as acknowledged.
-        /// Returns the offset value to commit (<c>hwm + 1</c>, per Kafka convention)
-        /// when a new contiguous run from the last committed point is complete;
-        /// otherwise returns <see langword="null"/>.
+        /// Marks <paramref name="offset"/> as acknowledged. Returns <c>hwm + 1</c> (Kafka commit convention)
+        /// when a contiguous run is complete; otherwise <see langword="null"/>.
         /// </summary>
         public long? Acknowledge(long offset)
         {
@@ -141,16 +77,13 @@ namespace Take.Elephant.Kafka
                     _epochStart    = offset;
                 }
 
-                // Discard stale acks from a previous epoch (e.g., delegates created before
-                // a Seek that fire after the reset). These offsets will never advance the HWM
-                // of the current epoch; keeping them in _acked would be a memory leak.
+                // Discard stale acks from a previous epoch; they'd cause a memory leak or spurious HWM advance.
                 if (offset < _epochStart)
                     return null;
 
                 _acked.Add(offset);
 
-                // Advance high-water mark while the next expected offset is either
-                // in the acked set or at the head of the phantom-gap queue.
+                // Advance HWM while the next expected offset is acked or at the head of a phantom range.
                 var hwm = _lastCommitted;
                 while (true)
                 {
@@ -162,8 +95,7 @@ namespace Take.Elephant.Kafka
                     }
                     else if (_phantomGaps.Count > 0 && _phantomGaps.Peek().Start == next)
                     {
-                        // Skip the entire phantom range in one O(1) step.
-                        hwm = _phantomGaps.Dequeue().End;
+                        hwm = _phantomGaps.Dequeue().End; // skip phantom range in O(1)
                     }
                     else
                     {
@@ -174,8 +106,7 @@ namespace Take.Elephant.Kafka
                 if (hwm > _lastCommitted)
                 {
                     _lastCommitted = hwm;
-                    // Kafka convention: commit = last processed offset + 1
-                    return hwm + 1;
+                    return hwm + 1; // Kafka convention: commit offset = last acked + 1
                 }
 
                 return null;

--- a/src/Take.Elephant.Kafka/PartitionCommitTracker.cs
+++ b/src/Take.Elephant.Kafka/PartitionCommitTracker.cs
@@ -95,6 +95,11 @@ namespace Take.Elephant.Kafka
                 if (epochId != _currentEpoch)
                     return null;
 
+                // Defense-in-depth: also reject any offset that predates the current epoch's start,
+                // guarding against edge cases where epochs match but the offset is otherwise stale.
+                if (offset < _epochStart)
+                    return null;
+
                 // Discard already-committed offsets to prevent unbounded _acked growth on duplicate acks.
                 if (offset <= _lastCommitted)
                     return null;

--- a/src/Take.Elephant.Kafka/PartitionCommitTracker.cs
+++ b/src/Take.Elephant.Kafka/PartitionCommitTracker.cs
@@ -20,26 +20,50 @@ namespace Take.Elephant.Kafka
     /// discarded; Kafka will redeliver the messages to the new owner.
     ///
     /// Algorithm:
-    ///   - <see cref="Track"/> bootstraps the high-water mark (HWM) on the first call
-    ///     so contiguity is relative to this assignment's starting offset.
-    ///   - <see cref="Acknowledge"/> adds the offset to the acked set and advances the
-    ///     HWM while the next expected offset is present in the set.
+    ///   - <see cref="Track"/> bootstraps the HWM on the first call and handles two
+    ///     classes of intra-assignment offset discontinuity:
+    ///     (a) Backward jumps (offset &lt; last tracked): caused by a manual
+    ///         <c>consumer.Seek()</c> to a prior position. The HWM, acked set, and
+    ///         phantom-gap queue are reset relative to the new position, and a new
+    ///         epoch boundary is recorded so that in-flight delegates from before the
+    ///         seek are discarded by <see cref="Acknowledge"/>.
+    ///     (b) Forward gaps (offset &gt; last tracked + 1): caused by log compaction,
+    ///         aborted transactions, or control records that are never delivered to
+    ///         consumers. These are <b>not</b> treated as resets.
+    ///         If no messages are currently in flight (all prior offsets have been
+    ///         committed), the HWM is advanced in O(1) to skip the gap.
+    ///         Otherwise, the gap is recorded as a <em>phantom range</em>
+    ///         <c>(start, end)</c> in a FIFO queue. During HWM advancement the entire
+    ///         range is skipped in a single O(1) dequeue, regardless of how large the
+    ///         gap is. This avoids the O(gap) per-offset allocation that would be
+    ///         required when pre-populating a sorted set with every phantom offset.
+    ///   - <see cref="Acknowledge"/> adds the offset to the acked set and advances
+    ///     the HWM while the next expected offset is either in the acked set or at the
+    ///     start of a phantom range. Acks for offsets below the current epoch boundary
+    ///     are discarded immediately to prevent stale delegates from causing a memory
+    ///     leak or a spurious commit.
+    ///
+    /// Known limitation: after a backward seek to offset S, in-flight ack delegates
+    /// created before the seek for offsets &gt;= S are not filtered (they share the
+    /// same epoch). In the unlikely scenario where such a stale ack arrives before its
+    /// corresponding replay-ack, it may accelerate the HWM. This is an inherent
+    /// trade-off of single-epoch tracking and is acceptable given that manual seeks are
+    /// rare in production consumers.
     ///
     /// Thread-safe.
     /// </summary>
-    /// <remarks>
-    /// <b>Known limitation:</b> this class does not detect intra-assignment offset
-    /// discontinuities (e.g., a manual <c>consumer.Seek()</c> within the same partition
-    /// assignment). If Seek is called outside of a rebalance event, the tracker will
-    /// wait indefinitely for missing offsets that will never arrive. In that scenario,
-    /// discard this instance and create a new <see cref="PartitionCommitTracker"/>
-    /// for the affected partition.
-    /// </remarks>
     internal sealed class PartitionCommitTracker
     {
         private readonly SortedSet<long> _acked = new SortedSet<long>();
+        // Phantom gap ranges: offsets that were never delivered (compacted / aborted records).
+        // Stored in FIFO order (same order as Track() calls). Each entry is (start, end) inclusive
+        // on both ends. The first entry in the queue is always the next phantom range the HWM will
+        // encounter, which is why a Queue is sufficient — gaps arrive and are consumed in strict order.
+        private readonly Queue<(long Start, long End)> _phantomGaps = new Queue<(long, long)>();
         private readonly object _lock = new object();
         private long _lastCommitted = long.MinValue; // uninitialized sentinel
+        private long _lastTracked   = long.MinValue; // last offset seen in Track(); used for discontinuity detection
+        private long _epochStart    = long.MinValue; // lowest valid offset of current epoch; stale acks below this are discarded
 
         /// <summary>
         /// Records that <paramref name="offset"/> was consumed. Must be called before
@@ -50,8 +74,52 @@ namespace Take.Elephant.Kafka
         {
             lock (_lock)
             {
-                if (_lastCommitted == long.MinValue)
+                if (_lastTracked == long.MinValue)
+                {
+                    // First call: bootstrap HWM relative to this assignment's starting offset.
                     _lastCommitted = offset - 1;
+                    _lastTracked   = offset;
+                    _epochStart    = offset;
+                    return;
+                }
+
+                if (offset != _lastTracked + 1)
+                {
+                    if (offset < _lastTracked)
+                    {
+                        // ── Backward jump: manual consumer.Seek() to a prior position ──────────
+                        // The offsets between _lastTracked and offset will never arrive again.
+                        // Reset HWM, the acked set, and the phantom-gap queue. Advance the epoch
+                        // boundary so that any Acknowledge() calls still in flight for the old
+                        // positions are silently discarded, preventing memory leaks and spurious
+                        // commits.
+                        _lastCommitted = offset - 1;
+                        _acked.Clear();
+                        _phantomGaps.Clear();
+                        _epochStart = offset;
+                    }
+                    else if (_acked.Count == 0 && _lastCommitted == _lastTracked)
+                    {
+                        // ── Forward gap, no messages in flight ────────────────────────────────
+                        // All previously tracked offsets have already been acked and committed
+                        // (_lastCommitted == _lastTracked). The gap offsets (compacted, aborted
+                        // transactions, control records) will never be delivered, so there is
+                        // nothing to wait for. Advance _lastCommitted directly in O(1).
+                        _lastCommitted = offset - 1;
+                    }
+                    else
+                    {
+                        // ── Forward gap with in-flight messages ───────────────────────────────
+                        // Some earlier offsets are still being processed concurrently.
+                        // Record the phantom range in O(1). The HWM advancement loop in
+                        // Acknowledge() will skip the entire range with a single Dequeue()
+                        // call when it reaches the start of the gap, avoiding any per-offset
+                        // allocation regardless of how large the gap is.
+                        _phantomGaps.Enqueue((_lastTracked + 1, offset - 1));
+                    }
+                }
+
+                _lastTracked = offset;
             }
         }
 
@@ -65,18 +133,42 @@ namespace Take.Elephant.Kafka
         {
             lock (_lock)
             {
-                // Bootstrap if Track was never called (purely defensive)
-                if (_lastCommitted == long.MinValue)
+                // Bootstrap defensively if Track was never called.
+                if (_lastTracked == long.MinValue)
+                {
                     _lastCommitted = offset - 1;
+                    _lastTracked   = offset;
+                    _epochStart    = offset;
+                }
+
+                // Discard stale acks from a previous epoch (e.g., delegates created before
+                // a Seek that fire after the reset). These offsets will never advance the HWM
+                // of the current epoch; keeping them in _acked would be a memory leak.
+                if (offset < _epochStart)
+                    return null;
 
                 _acked.Add(offset);
 
-                // Advance high-water mark while the next expected offset is acked
+                // Advance high-water mark while the next expected offset is either
+                // in the acked set or at the head of the phantom-gap queue.
                 var hwm = _lastCommitted;
-                while (_acked.Contains(hwm + 1))
+                while (true)
                 {
-                    hwm++;
-                    _acked.Remove(hwm);
+                    var next = hwm + 1;
+                    if (_acked.Contains(next))
+                    {
+                        hwm++;
+                        _acked.Remove(hwm);
+                    }
+                    else if (_phantomGaps.Count > 0 && _phantomGaps.Peek().Start == next)
+                    {
+                        // Skip the entire phantom range in one O(1) step.
+                        hwm = _phantomGaps.Dequeue().End;
+                    }
+                    else
+                    {
+                        break;
+                    }
                 }
 
                 if (hwm > _lastCommitted)

--- a/src/Take.Elephant.Kafka/PartitionCommitTracker.cs
+++ b/src/Take.Elephant.Kafka/PartitionCommitTracker.cs
@@ -17,10 +17,17 @@ namespace Take.Elephant.Kafka
         private readonly object _lock = new object();
         private long _lastCommitted = long.MinValue; // uninitialized sentinel
         private long _lastTracked   = long.MinValue; // last offset seen in Track()
-        private long _epochStart    = long.MinValue; // lowest valid offset for current assignment; stale acks below this are discarded
+        private long _epochStart    = long.MinValue; // lowest valid offset for current assignment
+        // Monotonically increasing counter: incremented on every backward seek so that all
+        // in-flight ack delegates from the old epoch are rejected, even for offsets that fall
+        // within the new epoch's offset range.
+        private long _currentEpoch  = 0;
 
-        /// <summary>Records a consumed offset. Must be called before dispatching downstream.</summary>
-        public void Track(long offset)
+        /// <summary>
+        /// Records a consumed offset. Must be called before dispatching downstream.
+        /// Returns the epoch id that must be passed to <see cref="Acknowledge"/> for this offset.
+        /// </summary>
+        public long Track(long offset)
         {
             lock (_lock)
             {
@@ -30,7 +37,7 @@ namespace Take.Elephant.Kafka
                     _lastCommitted = offset - 1;
                     _lastTracked   = offset;
                     _epochStart    = offset;
-                    return;
+                    return _currentEpoch;
                 }
 
                 if (offset != _lastTracked + 1)
@@ -38,11 +45,13 @@ namespace Take.Elephant.Kafka
                     if (offset < _lastTracked)
                     {
                         // Backward seek: reset HWM, acked set, and phantom-gap queue.
-                        // Advance epoch boundary to discard in-flight acks from the old position.
+                        // Advance epoch to invalidate ALL in-flight ack delegates from the old epoch,
+                        // including those whose offset happens to fall within the new epoch's range.
                         _lastCommitted = offset - 1;
                         _acked.Clear();
                         _phantomGaps.Clear();
                         _epochStart = offset;
+                        _currentEpoch++;
                     }
                     else if (_acked.Count == 0 && _lastCommitted == _lastTracked)
                     {
@@ -58,14 +67,17 @@ namespace Take.Elephant.Kafka
                 }
 
                 _lastTracked = offset;
+                return _currentEpoch;
             }
         }
 
         /// <summary>
-        /// Marks <paramref name="offset"/> as acknowledged. Returns <c>hwm + 1</c> (Kafka commit convention)
-        /// when a contiguous run is complete; otherwise <see langword="null"/>.
+        /// Marks <paramref name="offset"/> as acknowledged for the given <paramref name="epochId"/>.
+        /// Returns <c>hwm + 1</c> (Kafka commit convention) when a contiguous run is complete;
+        /// otherwise <see langword="null"/>.
+        /// Acks from a superseded epoch (e.g. issued before a backward seek) are silently discarded.
         /// </summary>
-        public long? Acknowledge(long offset)
+        public long? Acknowledge(long offset, long epochId)
         {
             lock (_lock)
             {
@@ -77,8 +89,14 @@ namespace Take.Elephant.Kafka
                     _epochStart    = offset;
                 }
 
-                // Discard stale acks from a previous epoch; they'd cause a memory leak or spurious HWM advance.
-                if (offset < _epochStart)
+                // Discard stale acks from a superseded epoch. This catches both offset-below-epochStart
+                // stale acks AND in-flight acks for offsets that fall within the new epoch's range but
+                // were tracked before the backward seek occurred.
+                if (epochId != _currentEpoch)
+                    return null;
+
+                // Discard already-committed offsets to prevent unbounded _acked growth on duplicate acks.
+                if (offset <= _lastCommitted)
                     return null;
 
                 _acked.Add(offset);

--- a/src/Take.Elephant.Kafka/PartitionCommitTracker.cs
+++ b/src/Take.Elephant.Kafka/PartitionCommitTracker.cs
@@ -1,0 +1,94 @@
+using System.Collections.Generic;
+
+namespace Take.Elephant.Kafka
+{
+    /// <summary>
+    /// Tracks acknowledged offsets for a single Kafka partition and returns the
+    /// highest contiguous offset safe to commit (i.e., all offsets from the last
+    /// committed point up to the returned offset have been acknowledged — no gaps).
+    ///
+    /// Each instance is scoped to one <see cref="Confluent.Kafka.TopicPartition"/>.
+    /// A new instance must be created whenever the partition is (re-)assigned after
+    /// a rebalance so that stale state from a previous assignment cannot block future
+    /// commits. The rebalance handlers in <see cref="KafkaReceiverQueue{T}"/> replace
+    /// the entry in <c>_partitionTrackers</c> with a fresh instance; the old instance
+    /// remains alive as long as in-flight delegates from before the rebalance still
+    /// hold a reference to it. Those delegates may call <see cref="Acknowledge"/> on
+    /// the old instance, advance its HWM, and then attempt a Kafka commit — which will
+    /// throw a <see cref="Confluent.Kafka.KafkaException"/> because the partition is no
+    /// longer owned by this consumer. That exception is caught in the ack delegate and
+    /// discarded; Kafka will redeliver the messages to the new owner.
+    ///
+    /// Algorithm:
+    ///   - <see cref="Track"/> bootstraps the high-water mark (HWM) on the first call
+    ///     so contiguity is relative to this assignment's starting offset.
+    ///   - <see cref="Acknowledge"/> adds the offset to the acked set and advances the
+    ///     HWM while the next expected offset is present in the set.
+    ///
+    /// Thread-safe.
+    /// </summary>
+    /// <remarks>
+    /// <b>Known limitation:</b> this class does not detect intra-assignment offset
+    /// discontinuities (e.g., a manual <c>consumer.Seek()</c> within the same partition
+    /// assignment). If Seek is called outside of a rebalance event, the tracker will
+    /// wait indefinitely for missing offsets that will never arrive. In that scenario,
+    /// discard this instance and create a new <see cref="PartitionCommitTracker"/>
+    /// for the affected partition.
+    /// </remarks>
+    internal sealed class PartitionCommitTracker
+    {
+        private readonly SortedSet<long> _acked = new SortedSet<long>();
+        private readonly object _lock = new object();
+        private long _lastCommitted = long.MinValue; // uninitialized sentinel
+
+        /// <summary>
+        /// Records that <paramref name="offset"/> was consumed. Must be called before
+        /// the message is dispatched downstream. Bootstraps the HWM on the first call
+        /// so that contiguity is relative to this run's starting offset.
+        /// </summary>
+        public void Track(long offset)
+        {
+            lock (_lock)
+            {
+                if (_lastCommitted == long.MinValue)
+                    _lastCommitted = offset - 1;
+            }
+        }
+
+        /// <summary>
+        /// Marks <paramref name="offset"/> as acknowledged.
+        /// Returns the offset value to commit (<c>hwm + 1</c>, per Kafka convention)
+        /// when a new contiguous run from the last committed point is complete;
+        /// otherwise returns <see langword="null"/>.
+        /// </summary>
+        public long? Acknowledge(long offset)
+        {
+            lock (_lock)
+            {
+                // Bootstrap if Track was never called (purely defensive)
+                if (_lastCommitted == long.MinValue)
+                    _lastCommitted = offset - 1;
+
+                _acked.Add(offset);
+
+                // Advance high-water mark while the next expected offset is acked
+                var hwm = _lastCommitted;
+                while (_acked.Contains(hwm + 1))
+                {
+                    hwm++;
+                    _acked.Remove(hwm);
+                }
+
+                if (hwm > _lastCommitted)
+                {
+                    _lastCommitted = hwm;
+                    // Kafka convention: commit = last processed offset + 1
+                    return hwm + 1;
+                }
+
+                return null;
+            }
+        }
+    }
+}
+

--- a/src/Take.Elephant.Tests/Kafka/KafkaReceiverQueueAckModeFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaReceiverQueueAckModeFacts.cs
@@ -414,36 +414,49 @@ namespace Take.Elephant.Tests.Kafka
             await queue.CloseAsync(CancellationToken.None);
         }
 
-        // ─── Factory class — compile-time type safety ─────────────────────────────
+        // ─── Factory class — concrete return type and lifecycle access ──────────
 
         [Fact]
-        public void Factory_CreateEager_ReturnsIKafkaReceiverQueue()
+        public void Factory_CreateEager_ReturnsConcreteType_AssignableToIKafkaReceiverQueue()
         {
-            // The factory must return the narrowest interface for the requested mode.
-            // CreateEager → IKafkaReceiverQueue<T>
-            // CreateOnSuccess/CreateManual → IKafkaAckableReceiverQueue<T>
-            // Because IKafkaAckableReceiverQueue<T> does NOT extend IKafkaReceiverQueue<T>,
-            // assigning the result of CreateOnSuccess/CreateManual to IKafkaReceiverQueue<T>
-            // is a compile-time error (CS0266) — the factory enforces this at the type level.
+            // Factory returns the concrete KafkaReceiverQueue<T> so callers have direct
+            // access to lifecycle methods (OpenAsync, CloseAsync, Dispose) without cast.
+            // The concrete type is still assignable to IKafkaReceiverQueue<T> and
+            // IKafkaAckableReceiverQueue<T> for callers that want the narrower interface.
             var config = new ConsumerConfig { BootstrapServers = "localhost:9092", GroupId = "g" };
             var serializer = Substitute.For<ISerializer<TestItem>>();
 
-            IKafkaReceiverQueue<TestItem> eager = KafkaReceiverQueue.CreateEager<TestItem>(config, "t", serializer);
+            KafkaReceiverQueue<TestItem> eager = KafkaReceiverQueue.CreateEager<TestItem>(config, "t", serializer);
             Assert.NotNull(eager);
+            Assert.IsAssignableFrom<IKafkaReceiverQueue<TestItem>>(eager);
 
-            IKafkaAckableReceiverQueue<TestItem> onSuccess = KafkaReceiverQueue.CreateOnSuccess<TestItem>(config, "t", serializer);
+            KafkaReceiverQueue<TestItem> onSuccess = KafkaReceiverQueue.CreateOnSuccess<TestItem>(config, "t", serializer);
             Assert.NotNull(onSuccess);
+            Assert.IsAssignableFrom<IKafkaAckableReceiverQueue<TestItem>>(onSuccess);
 
-            IKafkaAckableReceiverQueue<TestItem> manual = KafkaReceiverQueue.CreateManual<TestItem>(config, "t", serializer);
+            KafkaReceiverQueue<TestItem> manual = KafkaReceiverQueue.CreateManual<TestItem>(config, "t", serializer);
             Assert.NotNull(manual);
+            Assert.IsAssignableFrom<IKafkaAckableReceiverQueue<TestItem>>(manual);
 
-            // The ackable references must NOT be implicitly castable to IKafkaReceiverQueue<T>.
-            // (Verified at compile time by the explicit type annotations above — if the factory
-            // returned IKafkaReceiverQueue<T>, the lines above would not compile.)
+            eager.Dispose();
+            onSuccess.Dispose();
+            manual.Dispose();
+        }
 
-            (eager as IDisposable)?.Dispose();
-            (onSuccess as IDisposable)?.Dispose();
-            (manual as IDisposable)?.Dispose();
+        [Fact]
+        public async Task Factory_ConcreteReturn_LifecycleAccessibleWithoutCast()
+        {
+            // Verifies that OpenAsync, CloseAsync and Dispose are accessible directly
+            // on the factory return value — no cast to IOpenable/ICloseable/IDisposable needed.
+            var config = new ConsumerConfig { BootstrapServers = "localhost:9092", GroupId = "g" };
+            var serializer = Substitute.For<ISerializer<TestItem>>();
+
+            KafkaReceiverQueue<TestItem> queue = KafkaReceiverQueue.CreateEager<TestItem>(config, "t", serializer);
+
+            // All three lifecycle methods must be callable directly (compile-time proof).
+            await queue.OpenAsync(CancellationToken.None);
+            await queue.CloseAsync(CancellationToken.None);
+            queue.Dispose();
         }
 
         // ─── Concurrent ack ordering — monotonic commit ───────────────────────────

--- a/src/Take.Elephant.Tests/Kafka/KafkaReceiverQueueAckModeFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaReceiverQueueAckModeFacts.cs
@@ -1,0 +1,304 @@
+using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Confluent.Kafka;
+using NSubstitute;
+using Take.Elephant.Kafka;
+using Xunit;
+
+namespace Take.Elephant.Tests.Kafka
+{
+    [Trait("Category", nameof(Kafka))]
+    public class KafkaReceiverQueueAckModeFacts
+    {
+        // ─── Helpers ──────────────────────────────────────────────────────────────
+
+        private static (IConsumer<Ignore, string> Consumer, ISerializer<TestItem> Serializer, KafkaReceiverQueue<TestItem> Queue)
+            BuildQueue(KafkaAckMode ackMode, params ConsumeResult<Ignore, string>[] sequence)
+        {
+            var serializer = Substitute.For<ISerializer<TestItem>>();
+            var consumer = Substitute.For<IConsumer<Ignore, string>>();
+            consumer.Subscription.Returns(new List<string>());
+
+            SetupConsumeSequence(consumer, sequence);
+
+            var queue = new KafkaReceiverQueue<TestItem>(consumer, serializer, "test-topic", ackMode);
+            return (consumer, serializer, queue);
+        }
+
+        private static ConsumeResult<Ignore, string> MakeResult(string serializedValue, int partition = 0, long offset = 0)
+        {
+            return new ConsumeResult<Ignore, string>
+            {
+                Topic = "test-topic",
+                Partition = new Partition(partition),
+                Offset = new Offset(offset),
+                Message = new Message<Ignore, string>
+                {
+                    Value = serializedValue,
+                    Headers = new Headers()
+                }
+            };
+        }
+
+        private static void SetupConsumeSequence(IConsumer<Ignore, string> consumer, ConsumeResult<Ignore, string>[] sequence)
+        {
+            var calls = 0;
+            consumer
+                .Consume(Arg.Any<CancellationToken>())
+                .Returns(callInfo =>
+                {
+                    var ct = callInfo.Arg<CancellationToken>();
+                    if (calls < sequence.Length)
+                        return sequence[calls++];
+
+                    ct.WaitHandle.WaitOne();
+                    throw new OperationCanceledException(ct);
+                });
+        }
+
+        // ─── Eager mode (legacy) ─────────────────────────────────────────────────
+
+        [Fact]
+        public async Task EagerMode_DequeueAsync_ReturnsItem_WithoutExplicitAck()
+        {
+            var item = new TestItem { Value = "eager-payload" };
+            var result = MakeResult("ser-eager");
+            var (_, serializer, queue) = BuildQueue(KafkaAckMode.Eager, result);
+            serializer.Deserialize("ser-eager").Returns(item);
+
+            var dequeued = await queue.DequeueAsync(CancellationToken.None);
+
+            Assert.Same(item, dequeued);
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EagerMode_DequeueAckableAsync_ThrowsInvalidOperationException()
+        {
+            var (_, _, queue) = BuildQueue(KafkaAckMode.Eager);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => queue.DequeueAckableAsync(CancellationToken.None));
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EagerMode_DequeueAckableOrDefaultAsync_ThrowsInvalidOperationException()
+        {
+            var (_, _, queue) = BuildQueue(KafkaAckMode.Eager);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => queue.DequeueAckableOrDefaultAsync(CancellationToken.None));
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        // ─── OnSuccess mode ───────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task OnSuccessMode_DequeueAckableAsync_ReturnsAckableMessage()
+        {
+            var item = new TestItem { Value = "on-success" };
+            var result = MakeResult("ser-ok", partition: 0, offset: 5);
+            var (_, serializer, queue) = BuildQueue(KafkaAckMode.OnSuccess, result);
+            serializer.Deserialize("ser-ok").Returns(item);
+
+            var msg = await queue.DequeueAckableAsync(CancellationToken.None);
+
+            Assert.Same(item, msg.Item);
+            Assert.Equal("test-topic", msg.Topic);
+            Assert.Equal(0, msg.Partition);
+            Assert.Equal(5L, msg.Offset);
+            Assert.False(msg.IsAcknowledged);
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task OnSuccessMode_AcknowledgeAsync_CommitsOffset()
+        {
+            var item = new TestItem { Value = "on-success-ack" };
+            var result = MakeResult("ser-ack", partition: 1, offset: 10);
+            var (consumer, serializer, queue) = BuildQueue(KafkaAckMode.OnSuccess, result);
+            serializer.Deserialize("ser-ack").Returns(item);
+
+            var msg = await queue.DequeueAckableAsync(CancellationToken.None);
+            await msg.AcknowledgeAsync();
+
+            Assert.True(msg.IsAcknowledged);
+            // After ack, StoreOffset should be called with offset 11 (10+1)
+            consumer.Received(1).StoreOffset(
+                Arg.Is<TopicPartitionOffset>(tpo => tpo.Offset == new Offset(11)));
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task OnSuccessMode_AcknowledgeAsync_IsIdempotent()
+        {
+            var item = new TestItem { Value = "idempotent" };
+            var result = MakeResult("ser-idem", partition: 0, offset: 7);
+            var (consumer, serializer, queue) = BuildQueue(KafkaAckMode.OnSuccess, result);
+            serializer.Deserialize("ser-idem").Returns(item);
+
+            var msg = await queue.DequeueAckableAsync(CancellationToken.None);
+
+            // Invoke ack twice
+            await msg.AcknowledgeAsync();
+            await msg.AcknowledgeAsync();
+
+            // StoreOffset and Commit must be called exactly once
+            consumer.Received(1).StoreOffset(Arg.Any<TopicPartitionOffset>());
+            consumer.Received(1).Commit(Arg.Any<IEnumerable<TopicPartitionOffset>>());
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task OnSuccessMode_NoCommit_BeforeAcknowledge()
+        {
+            var item = new TestItem { Value = "no-commit" };
+            var result = MakeResult("ser-nc", partition: 0, offset: 3);
+            var (consumer, serializer, queue) = BuildQueue(KafkaAckMode.OnSuccess, result);
+            serializer.Deserialize("ser-nc").Returns(item);
+
+            var msg = await queue.DequeueAckableAsync(CancellationToken.None);
+
+            // Do NOT ack
+            consumer.DidNotReceive().StoreOffset(Arg.Any<TopicPartitionOffset>());
+            consumer.DidNotReceive().Commit(Arg.Any<IEnumerable<TopicPartitionOffset>>());
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        // ─── Manual mode ──────────────────────────────────────────────────────────
+
+        [Fact]
+        public async Task ManualMode_BehavesLikeOnSuccess_ForAck()
+        {
+            var item = new TestItem { Value = "manual" };
+            var result = MakeResult("ser-man", partition: 2, offset: 100);
+            var (consumer, serializer, queue) = BuildQueue(KafkaAckMode.Manual, result);
+            serializer.Deserialize("ser-man").Returns(item);
+
+            var msg = await queue.DequeueAckableAsync(CancellationToken.None);
+            await msg.AcknowledgeAsync();
+
+            Assert.True(msg.IsAcknowledged);
+            consumer.Received(1).StoreOffset(
+                Arg.Is<TopicPartitionOffset>(tpo => tpo.Offset == new Offset(101)));
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        // ─── PartitionCommitTracker in-order contiguous ───────────────────────────
+
+        [Fact]
+        public async Task OnSuccessMode_TwoMessagesInOrder_BothCommitSequentially()
+        {
+            var item1 = new TestItem { Value = "msg1" };
+            var item2 = new TestItem { Value = "msg2" };
+            var (consumer, serializer, queue) = BuildQueue(
+                KafkaAckMode.OnSuccess,
+                MakeResult("ser1", partition: 0, offset: 0),
+                MakeResult("ser2", partition: 0, offset: 1));
+            serializer.Deserialize("ser1").Returns(item1);
+            serializer.Deserialize("ser2").Returns(item2);
+
+            var msg1 = await queue.DequeueAckableAsync(CancellationToken.None);
+            var msg2 = await queue.DequeueAckableAsync(CancellationToken.None);
+
+            // Ack in order
+            await msg1.AcknowledgeAsync();
+            // Commit should be at offset=1 (0+1)
+            consumer.Received(1).StoreOffset(Arg.Is<TopicPartitionOffset>(tpo => tpo.Offset == new Offset(1)));
+
+            await msg2.AcknowledgeAsync();
+            // Commit should be at offset=2 (1+1)
+            consumer.Received(1).StoreOffset(Arg.Is<TopicPartitionOffset>(tpo => tpo.Offset == new Offset(2)));
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task OnSuccessMode_TwoMessagesOutOfOrder_HWMAdvancesOnlyAfterGapFilled()
+        {
+            var item1 = new TestItem { Value = "msg1" };
+            var item2 = new TestItem { Value = "msg2" };
+            var (consumer, serializer, queue) = BuildQueue(
+                KafkaAckMode.OnSuccess,
+                MakeResult("ser1", partition: 0, offset: 0),
+                MakeResult("ser2", partition: 0, offset: 1));
+            serializer.Deserialize("ser1").Returns(item1);
+            serializer.Deserialize("ser2").Returns(item2);
+
+            var msg1 = await queue.DequeueAckableAsync(CancellationToken.None);
+            var msg2 = await queue.DequeueAckableAsync(CancellationToken.None);
+
+            // Ack msg2 first (out-of-order) — should NOT commit because offset 0 is still pending
+            await msg2.AcknowledgeAsync();
+            consumer.DidNotReceive().StoreOffset(Arg.Any<TopicPartitionOffset>());
+
+            // Now ack msg1 — fills the gap, HWM advances to offset 1, commits at offset=2
+            await msg1.AcknowledgeAsync();
+            consumer.Received(1).StoreOffset(Arg.Is<TopicPartitionOffset>(tpo => tpo.Offset == new Offset(2)));
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        // ─── OnSuccess mode: non-ackable Dequeue methods throw ───────────────────
+
+        [Fact]
+        public async Task OnSuccessMode_DequeueAsync_ThrowsInvalidOperationException()
+        {
+            var (_, _, queue) = BuildQueue(KafkaAckMode.OnSuccess);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => queue.DequeueAsync(CancellationToken.None));
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task OnSuccessMode_DequeueOrDefaultAsync_ThrowsInvalidOperationException()
+        {
+            var (_, _, queue) = BuildQueue(KafkaAckMode.OnSuccess);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => queue.DequeueOrDefaultAsync(CancellationToken.None));
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task OnSuccessMode_DequeueWithHeadersAsync_ThrowsInvalidOperationException()
+        {
+            var (_, _, queue) = BuildQueue(KafkaAckMode.OnSuccess);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => queue.DequeueWithHeadersAsync(CancellationToken.None));
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task OnSuccessMode_DequeueWithHeadersOrDefaultAsync_ThrowsInvalidOperationException()
+        {
+            var (_, _, queue) = BuildQueue(KafkaAckMode.OnSuccess);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => queue.DequeueWithHeadersOrDefaultAsync(CancellationToken.None));
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        public sealed class TestItem
+        {
+            public string Value { get; set; }
+        }
+    }
+}

--- a/src/Take.Elephant.Tests/Kafka/KafkaReceiverQueueAckModeFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/KafkaReceiverQueueAckModeFacts.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
@@ -24,7 +26,12 @@ namespace Take.Elephant.Tests.Kafka
 
             SetupConsumeSequence(consumer, sequence);
 
-            var queue = new KafkaReceiverQueue<TestItem>(consumer, serializer, "test-topic", ackMode);
+            // Non-Eager modes require the internal constructor (test seam) because the public
+            // constructor enforces Eager-only for injected consumers.
+            var queue = ackMode == KafkaAckMode.Eager
+                ? new KafkaReceiverQueue<TestItem>(consumer, serializer, "test-topic", ackMode)
+                : new KafkaReceiverQueue<TestItem>(consumer, serializer, "test-topic", ackMode,
+                    new ConcurrentDictionary<TopicPartition, PartitionCommitTracker>());
             return (consumer, serializer, queue);
         }
 
@@ -130,9 +137,11 @@ namespace Take.Elephant.Tests.Kafka
             await msg.AcknowledgeAsync();
 
             Assert.True(msg.IsAcknowledged);
-            // After ack, StoreOffset should be called with offset 11 (10+1)
-            consumer.Received(1).StoreOffset(
-                Arg.Is<TopicPartitionOffset>(tpo => tpo.Offset == new Offset(11)));
+            // After ack, Commit should be called with offset 11 (10+1, per Kafka convention).
+            // StoreOffset is no longer called: Commit(explicit) bypasses the local offset store.
+            consumer.Received(1).Commit(
+                Arg.Is<IEnumerable<TopicPartitionOffset>>(tpos =>
+                    tpos.Any(tpo => tpo.Offset == new Offset(11))));
 
             await queue.CloseAsync(CancellationToken.None);
         }
@@ -151,8 +160,8 @@ namespace Take.Elephant.Tests.Kafka
             await msg.AcknowledgeAsync();
             await msg.AcknowledgeAsync();
 
-            // StoreOffset and Commit must be called exactly once
-            consumer.Received(1).StoreOffset(Arg.Any<TopicPartitionOffset>());
+            // Commit must be called exactly once; StoreOffset is no longer called.
+            consumer.DidNotReceive().StoreOffset(Arg.Any<TopicPartitionOffset>());
             consumer.Received(1).Commit(Arg.Any<IEnumerable<TopicPartitionOffset>>());
 
             await queue.CloseAsync(CancellationToken.None);
@@ -168,7 +177,7 @@ namespace Take.Elephant.Tests.Kafka
 
             var msg = await queue.DequeueAckableAsync(CancellationToken.None);
 
-            // Do NOT ack
+            // Do NOT ack — neither StoreOffset nor Commit should be called.
             consumer.DidNotReceive().StoreOffset(Arg.Any<TopicPartitionOffset>());
             consumer.DidNotReceive().Commit(Arg.Any<IEnumerable<TopicPartitionOffset>>());
 
@@ -189,8 +198,10 @@ namespace Take.Elephant.Tests.Kafka
             await msg.AcknowledgeAsync();
 
             Assert.True(msg.IsAcknowledged);
-            consumer.Received(1).StoreOffset(
-                Arg.Is<TopicPartitionOffset>(tpo => tpo.Offset == new Offset(101)));
+            consumer.DidNotReceive().StoreOffset(Arg.Any<TopicPartitionOffset>());
+            consumer.Received(1).Commit(
+                Arg.Is<IEnumerable<TopicPartitionOffset>>(tpos =>
+                    tpos.Any(tpo => tpo.Offset == new Offset(101))));
 
             await queue.CloseAsync(CancellationToken.None);
         }
@@ -215,11 +226,15 @@ namespace Take.Elephant.Tests.Kafka
             // Ack in order
             await msg1.AcknowledgeAsync();
             // Commit should be at offset=1 (0+1)
-            consumer.Received(1).StoreOffset(Arg.Is<TopicPartitionOffset>(tpo => tpo.Offset == new Offset(1)));
+            consumer.Received(1).Commit(
+                Arg.Is<IEnumerable<TopicPartitionOffset>>(tpos =>
+                    tpos.Any(tpo => tpo.Offset == new Offset(1))));
 
             await msg2.AcknowledgeAsync();
             // Commit should be at offset=2 (1+1)
-            consumer.Received(1).StoreOffset(Arg.Is<TopicPartitionOffset>(tpo => tpo.Offset == new Offset(2)));
+            consumer.Received(1).Commit(
+                Arg.Is<IEnumerable<TopicPartitionOffset>>(tpos =>
+                    tpos.Any(tpo => tpo.Offset == new Offset(2))));
 
             await queue.CloseAsync(CancellationToken.None);
         }
@@ -242,10 +257,14 @@ namespace Take.Elephant.Tests.Kafka
             // Ack msg2 first (out-of-order) — should NOT commit because offset 0 is still pending
             await msg2.AcknowledgeAsync();
             consumer.DidNotReceive().StoreOffset(Arg.Any<TopicPartitionOffset>());
+            consumer.DidNotReceive().Commit(Arg.Any<IEnumerable<TopicPartitionOffset>>());
 
             // Now ack msg1 — fills the gap, HWM advances to offset 1, commits at offset=2
             await msg1.AcknowledgeAsync();
-            consumer.Received(1).StoreOffset(Arg.Is<TopicPartitionOffset>(tpo => tpo.Offset == new Offset(2)));
+            consumer.DidNotReceive().StoreOffset(Arg.Any<TopicPartitionOffset>());
+            consumer.Received(1).Commit(
+                Arg.Is<IEnumerable<TopicPartitionOffset>>(tpos =>
+                    tpos.Any(tpo => tpo.Offset == new Offset(2))));
 
             await queue.CloseAsync(CancellationToken.None);
         }
@@ -292,6 +311,290 @@ namespace Take.Elephant.Tests.Kafka
 
             await Assert.ThrowsAsync<InvalidOperationException>(
                 () => queue.DequeueWithHeadersOrDefaultAsync(CancellationToken.None));
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        // ─── DequeueAckable* guards run before consumer is started (C6/C7) ─────────
+
+        [Fact]
+        public async Task EagerMode_DequeueAckableAsync_ThrowsBeforeStartingConsumer()
+        {
+            // Guard must fire synchronously (before any await inside) so the consumer
+            // loop is never started as a side-effect of a misuse call.
+            var (consumer, _, queue) = BuildQueue(KafkaAckMode.Eager);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => queue.DequeueAckableAsync(CancellationToken.None));
+
+            // If the consumer task had been started, Consume() would have been called.
+            consumer.DidNotReceive().Consume(Arg.Any<CancellationToken>());
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task EagerMode_DequeueAckableOrDefaultAsync_ThrowsBeforeStartingConsumer()
+        {
+            var (consumer, _, queue) = BuildQueue(KafkaAckMode.Eager);
+
+            await Assert.ThrowsAsync<InvalidOperationException>(
+                () => queue.DequeueAckableOrDefaultAsync(CancellationToken.None));
+
+            consumer.DidNotReceive().Consume(Arg.Any<CancellationToken>());
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        // ─── Ack delegate swallows disposal exceptions during shutdown (C2) ────────
+
+        [Fact]
+        public async Task OnSuccessMode_AcknowledgeAsync_AfterClose_DoesNotThrow()
+        {
+            // Simulates a message that was dequeued and is still in-flight when
+            // CloseAsync is called. The ack delegate must swallow any disposal
+            // exception rather than surfacing it to the caller.
+            var item = new TestItem { Value = "in-flight" };
+            var result = MakeResult("ser-in-flight", partition: 0, offset: 0);
+            var (consumer, serializer, queue) = BuildQueue(KafkaAckMode.OnSuccess, result);
+            serializer.Deserialize("ser-in-flight").Returns(item);
+
+            // Make Commit throw ObjectDisposedException to simulate a closed consumer.
+            consumer
+                .When(c => c.Commit(Arg.Any<IEnumerable<TopicPartitionOffset>>()))
+                .Do(_ => throw new ObjectDisposedException("_consumer"));
+
+            await queue.OpenAsync(CancellationToken.None);
+            var ackable = await queue.DequeueAckableAsync(CancellationToken.None);
+            await queue.CloseAsync(CancellationToken.None);
+
+            // Must not throw even though the consumer is now closed.
+            var ex = await Record.ExceptionAsync(() => ackable.AcknowledgeAsync());
+            Assert.Null(ex);
+        }
+
+        [Fact]
+        public async Task OnSuccessMode_AcknowledgeAsync_BrokerException_IsRetryable()
+        {
+            // After a broker-level commit failure, IsAcknowledged must be false so
+            // the caller can retry. On retry the cached commit offset is reused
+            // (the tracker HWM has already advanced) and the second Commit() succeeds.
+            var item = new TestItem { Value = "retry" };
+            var tp = new TopicPartition("test-topic", new Partition(0));
+            var result = MakeResult("ser-retry", partition: 0, offset: 0);
+            var (consumer, serializer, queue, trackers) = BuildQueueWithTrackers(KafkaAckMode.OnSuccess, result);
+            serializer.Deserialize("ser-retry").Returns(item);
+
+            var tracker = new PartitionCommitTracker();
+            trackers[tp] = tracker;
+
+            // First Commit() call throws; second succeeds.
+            var commitCallCount = 0;
+            consumer
+                .When(c => c.Commit(Arg.Any<IEnumerable<TopicPartitionOffset>>()))
+                .Do(_ =>
+                {
+                    if (++commitCallCount == 1)
+                        throw new KafkaException(new Error(ErrorCode.Local_AllBrokersDown));
+                });
+
+            var msg = await queue.DequeueAckableAsync(CancellationToken.None);
+
+            // First ack fails — IsAcknowledged must remain false for retry.
+            await Assert.ThrowsAsync<KafkaException>(() => msg.AcknowledgeAsync());
+            Assert.False(msg.IsAcknowledged);
+
+            // Retry: second ack must succeed and mark the message as acknowledged.
+            await msg.AcknowledgeAsync();
+            Assert.True(msg.IsAcknowledged);
+
+            // Both attempts must have called Commit (second used cached commit offset).
+            consumer.Received(2).Commit(Arg.Any<IEnumerable<TopicPartitionOffset>>());
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        // ─── Factory class — compile-time type safety ─────────────────────────────
+
+        [Fact]
+        public void Factory_CreateEager_ReturnsIKafkaReceiverQueue()
+        {
+            // The factory must return the narrowest interface for the requested mode.
+            // CreateEager → IKafkaReceiverQueue<T>
+            // CreateOnSuccess/CreateManual → IKafkaAckableReceiverQueue<T>
+            // Because IKafkaAckableReceiverQueue<T> does NOT extend IKafkaReceiverQueue<T>,
+            // assigning the result of CreateOnSuccess/CreateManual to IKafkaReceiverQueue<T>
+            // is a compile-time error (CS0266) — the factory enforces this at the type level.
+            var config = new ConsumerConfig { BootstrapServers = "localhost:9092", GroupId = "g" };
+            var serializer = Substitute.For<ISerializer<TestItem>>();
+
+            IKafkaReceiverQueue<TestItem> eager = KafkaReceiverQueue.CreateEager<TestItem>(config, "t", serializer);
+            Assert.NotNull(eager);
+
+            IKafkaAckableReceiverQueue<TestItem> onSuccess = KafkaReceiverQueue.CreateOnSuccess<TestItem>(config, "t", serializer);
+            Assert.NotNull(onSuccess);
+
+            IKafkaAckableReceiverQueue<TestItem> manual = KafkaReceiverQueue.CreateManual<TestItem>(config, "t", serializer);
+            Assert.NotNull(manual);
+
+            // The ackable references must NOT be implicitly castable to IKafkaReceiverQueue<T>.
+            // (Verified at compile time by the explicit type annotations above — if the factory
+            // returned IKafkaReceiverQueue<T>, the lines above would not compile.)
+
+            (eager as IDisposable)?.Dispose();
+            (onSuccess as IDisposable)?.Dispose();
+            (manual as IDisposable)?.Dispose();
+        }
+
+        // ─── Concurrent ack ordering — monotonic commit ───────────────────────────
+
+        [Fact]
+        public async Task OnSuccessMode_TwoMessagesAckedConcurrently_CommitsAreMonotonic()
+        {
+            // Two messages on the same partition processed concurrently.
+            // Regardless of which ack wins the per-partition commit lock, the monotonic
+            // guard must ensure the broker cursor never regresses (a lower-offset commit
+            // is suppressed once a higher-offset one has been issued for the same partition).
+            var item1 = new TestItem { Value = "msg1" };
+            var item2 = new TestItem { Value = "msg2" };
+            var tp = new TopicPartition("test-topic", new Partition(0));
+            var (consumer, serializer, queue, trackers) = BuildQueueWithTrackers(
+                KafkaAckMode.OnSuccess,
+                MakeResult("ser1", partition: 0, offset: 0),
+                MakeResult("ser2", partition: 0, offset: 1));
+            serializer.Deserialize("ser1").Returns(item1);
+            serializer.Deserialize("ser2").Returns(item2);
+
+            var tracker = new PartitionCommitTracker();
+            trackers[tp] = tracker;
+
+            var msg1 = await queue.DequeueAckableAsync(CancellationToken.None);
+            var msg2 = await queue.DequeueAckableAsync(CancellationToken.None);
+
+            // Ack both concurrently.
+            await Task.WhenAll(
+                Task.Run(() => msg1.AcknowledgeAsync()),
+                Task.Run(() => msg2.AcknowledgeAsync()));
+
+            Assert.True(msg1.IsAcknowledged);
+            Assert.True(msg2.IsAcknowledged);
+
+            // Collect committed offsets in the order they were issued.
+            var commitOffsets = consumer.ReceivedCalls()
+                .Where(c => c.GetMethodInfo().Name == nameof(IConsumer<Ignore, string>.Commit))
+                .Select(c => c.GetArguments()[0] as IEnumerable<TopicPartitionOffset>)
+                .Where(x => x != null)
+                .SelectMany(x => x)
+                .Select(tpo => tpo.Offset.Value)
+                .ToList();
+
+            Assert.NotEmpty(commitOffsets);
+            // The highest committed offset must cover both messages (offsets 0 and 1 → commit at 2).
+            Assert.Equal(2L, commitOffsets.Max());
+            // No commit must regress (monotonically non-decreasing).
+            for (int i = 1; i < commitOffsets.Count; i++)
+                Assert.True(commitOffsets[i] >= commitOffsets[i - 1],
+                    $"Commit regressed: offset {commitOffsets[i - 1]} → {commitOffsets[i]}");
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        // ─── Constructor contract ─────────────────────────────────────────────────
+
+        [Theory]
+        [InlineData(KafkaAckMode.OnSuccess)]
+        [InlineData(KafkaAckMode.Manual)]
+        public void PublicIConsumerConstructor_WhenNonEagerMode_ThrowsArgumentException(KafkaAckMode ackMode)
+        {
+            var consumer = Substitute.For<IConsumer<Ignore, string>>();
+            var serializer = Substitute.For<ISerializer<TestItem>>();
+
+            var ex = Assert.Throws<ArgumentException>(() =>
+                new KafkaReceiverQueue<TestItem>(consumer, serializer, "test-topic", ackMode));
+
+            Assert.Equal("ackMode", ex.ParamName);
+        }
+
+        // ─── KafkaException narrowing (Fix 2) ─────────────────────────────────────
+
+        /// <summary>
+        /// Returns the queue AND the underlying partition-tracker dictionary so that
+        /// tests can simulate rebalance events by manipulating the dictionary directly.
+        /// </summary>
+        private static (IConsumer<Ignore, string> Consumer,
+                        ISerializer<TestItem> Serializer,
+                        KafkaReceiverQueue<TestItem> Queue,
+                        ConcurrentDictionary<TopicPartition, PartitionCommitTracker> Trackers)
+            BuildQueueWithTrackers(KafkaAckMode ackMode, params ConsumeResult<Ignore, string>[] sequence)
+        {
+            var serializer = Substitute.For<ISerializer<TestItem>>();
+            var consumer = Substitute.For<IConsumer<Ignore, string>>();
+            consumer.Subscription.Returns(new List<string>());
+            SetupConsumeSequence(consumer, sequence);
+
+            var trackers = new ConcurrentDictionary<TopicPartition, PartitionCommitTracker>();
+            var queue = new KafkaReceiverQueue<TestItem>(consumer, serializer, "test-topic", ackMode, trackers);
+            return (consumer, serializer, queue, trackers);
+        }
+
+        [Fact]
+        public async Task OnSuccessMode_AcknowledgeAsync_BrokerException_Propagates()
+        {
+            // If the commit fails for a broker-level reason (e.g., all brokers down)
+            // while the partition is still active, the exception must propagate to the
+            // caller — it must NOT be silently swallowed.
+            var item = new TestItem { Value = "broker-fail" };
+            var tp = new TopicPartition("test-topic", new Partition(0));
+            var result = MakeResult("ser-bf", partition: 0, offset: 0);
+            var (consumer, serializer, queue, trackers) = BuildQueueWithTrackers(KafkaAckMode.OnSuccess, result);
+            serializer.Deserialize("ser-bf").Returns(item);
+
+            // Ensure the partition tracker is present in the dict (simulates active partition).
+            // Must be set before DequeueAckableAsync because that call starts the consumer task,
+            // which uses GetOrAdd — finding the entry here guarantees capturedTracker == tracker.
+            var tracker = new PartitionCommitTracker();
+            trackers[tp] = tracker;
+
+            // Simulate a broker-level commit failure (partition still active).
+            var brokerError = new Error(ErrorCode.Local_AllBrokersDown);
+            consumer
+                .When(c => c.Commit(Arg.Any<IEnumerable<TopicPartitionOffset>>()))
+                .Do(_ => throw new KafkaException(brokerError));
+
+            var msg = await queue.DequeueAckableAsync(CancellationToken.None);
+
+            // The exception must surface to the caller.
+            await Assert.ThrowsAsync<KafkaException>(() => msg.AcknowledgeAsync());
+
+            await queue.CloseAsync(CancellationToken.None);
+        }
+
+        [Fact]
+        public async Task OnSuccessMode_AcknowledgeAsync_PartitionRevoked_DoesNotThrow()
+        {
+            // If the partition was revoked (tracker removed from the dict) before
+            // AcknowledgeAsync is called, the commit should be skipped entirely.
+            var item = new TestItem { Value = "revoked" };
+            var tp = new TopicPartition("test-topic", new Partition(0));
+            var result = MakeResult("ser-rev", partition: 0, offset: 0);
+            var (consumer, serializer, queue, trackers) = BuildQueueWithTrackers(KafkaAckMode.OnSuccess, result);
+            serializer.Deserialize("ser-rev").Returns(item);
+
+            // Ensure the partition tracker is present so ConsumeAsync creates the ackable message.
+            var tracker = new PartitionCommitTracker();
+            trackers[tp] = tracker;
+
+            var msg = await queue.DequeueAckableAsync(CancellationToken.None);
+
+            // Simulate rebalance: remove the tracker before the ack fires.
+            trackers.TryRemove(tp, out _);
+
+            // Must not throw even though Commit would fail.
+            var ex = await Record.ExceptionAsync(() => msg.AcknowledgeAsync());
+            Assert.Null(ex);
+
+            // Commit must not have been attempted.
+            consumer.DidNotReceive().Commit(Arg.Any<IEnumerable<TopicPartitionOffset>>());
 
             await queue.CloseAsync(CancellationToken.None);
         }

--- a/src/Take.Elephant.Tests/Kafka/PartitionCommitTrackerFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/PartitionCommitTrackerFacts.cs
@@ -94,6 +94,183 @@ namespace Take.Elephant.Tests.Kafka
             Assert.Equal(102L, tracker.Acknowledge(101));
         }
 
+        // ─── Seek / intra-assignment offset discontinuity ─────────────────────────
+
+        [Fact]
+        public void Track_BackwardSeek_ResetsHWMToNewBase()
+        {
+            // Consumption starts at 50.
+            var tracker = new PartitionCommitTracker();
+            tracker.Track(50);
+            tracker.Track(51);
+            tracker.Acknowledge(50);    // HWM = 50, next expected = 51
+
+            // Seek backward to offset 10 (replaying old messages).
+            // 10 < 51 → backward branch → reset HWM, acked set, and phantom-gap queue.
+            tracker.Track(10);
+
+            // Ack 10 must commit at 11, not get confused by the previous HWM.
+            Assert.Equal(11L, tracker.Acknowledge(10));
+        }
+
+        // ─── Forward gaps (compaction / aborted transactions) ─────────────────────
+
+        [Fact]
+        public void Track_ForwardGap_WithInflight_PhantomRangeSkipped_HWMBlockedUntilPriorAcked()
+        {
+            // Scenario from reviewer: offsets 0 and 1 are in flight;
+            // offset 3 arrives because offset 2 was compacted.
+            // The tracker must NOT commit until both 0 and 1 are acked.
+            var tracker = new PartitionCommitTracker();
+            tracker.Track(0);
+            tracker.Track(1);
+            tracker.Track(3); // forward gap: phantom range (2,2) enqueued — O(1), no loop
+
+            // Ack 3 first (fast handler) — HWM cannot advance past 0's pending slot.
+            Assert.Null(tracker.Acknowledge(3));
+
+            // Ack 0 — HWM advances to 0, but stops because 1 is still pending.
+            Assert.Equal(1L, tracker.Acknowledge(0));
+
+            // Ack 1 — fills the real gap; the phantom range (2,2) is dequeued in one step;
+            // HWM bulk-advances through 1 → phantom 2 → 3 → commit at 4.
+            Assert.Equal(4L, tracker.Acknowledge(1));
+        }
+
+        [Fact]
+        public void Track_ForwardGap_WithoutInflight_AdvancesHWMInO1()
+        {
+            // All prior offsets are committed before the gap arrives.
+            // No phantom loop needed — _lastCommitted jumps directly.
+            var tracker = new PartitionCommitTracker();
+            tracker.Track(0);
+            tracker.Track(1);
+            tracker.Track(2);
+            Assert.Equal(1L, tracker.Acknowledge(0));
+            Assert.Equal(2L, tracker.Acknowledge(1));
+            Assert.Equal(3L, tracker.Acknowledge(2)); // _lastCommitted==2 == _lastTracked==2, _acked={}
+
+            // Gap: offsets 3–99 were compacted; 100 is the next delivered offset.
+            tracker.Track(100); // forward gap, no in-flight → O(1) advance
+
+            // Ack 100 should commit at 101 immediately (no phantom loop necessary).
+            Assert.Equal(101L, tracker.Acknowledge(100));
+        }
+
+        [Fact]
+        public void Track_ForwardGap_WithInflight_PhantomRangeDequeued_NoMemoryLeak()
+        {
+            // The phantom range must be removed from the queue as the HWM advances through it.
+            // This test verifies that the queue does not retain phantom ranges after the HWM passes.
+            var tracker = new PartitionCommitTracker();
+            tracker.Track(0);
+            tracker.Track(5); // forward gap with 0 still in flight → phantom range (1,4) enqueued
+
+            // Ack 5 first — HWM stuck at -1 (waiting for 0).
+            Assert.Null(tracker.Acknowledge(5));
+
+            // Ack 0 — HWM advances: 0 → phantom range (1,4) dequeued (skip to 4) → 5 → stop. Commit at 6.
+            Assert.Equal(6L, tracker.Acknowledge(0));
+
+            // Subsequent track/ack at 6 confirms no leftover state in _acked.
+            tracker.Track(6);
+            Assert.Equal(7L, tracker.Acknowledge(6));
+        }
+
+        [Fact]
+        public void Track_MultipleForwardGaps_EachGapHandledCorrectly()
+        {
+            // Two separate compaction gaps in the same assignment.
+            var tracker = new PartitionCommitTracker();
+            tracker.Track(0);
+            Assert.Equal(1L, tracker.Acknowledge(0)); // _lastCommitted=0, _lastTracked=0
+
+            // Gap 1: offsets 1-4 compacted, 5 arrives.
+            // _acked={}, _lastCommitted(0)==_lastTracked(0) → O(1): _lastCommitted=4
+            tracker.Track(5);
+
+            // Ack 5: fills _acked, no gap → commit at 6.
+            Assert.Equal(6L, tracker.Acknowledge(5)); // _lastCommitted=5, _lastTracked=5
+
+            // Gap 2: offsets 6-9 compacted, 10 arrives.
+            // _acked={}, _lastCommitted(5)==_lastTracked(5) → O(1): _lastCommitted=9
+            tracker.Track(10);
+
+            Assert.Equal(11L, tracker.Acknowledge(10));
+        }
+
+        [Fact]
+        public void Track_BackwardSeek_StaleAcksBeforeEpochStart_Discarded()
+        {
+            // After a backward seek to offset 50, acks for offsets below 50 are discarded.
+            var tracker = new PartitionCommitTracker();
+            tracker.Track(100);
+            tracker.Track(101);
+
+            // Seek backward to 50.
+            tracker.Track(50); // backward: reset, _epochStart=50
+
+            // Ack for offset 40 (below epochStart=50) must be discarded.
+            Assert.Null(tracker.Acknowledge(40));
+
+            // Ack for the new epoch works normally.
+            Assert.Equal(51L, tracker.Acknowledge(50));
+        }
+
+        [Fact]
+        public void Track_MultipleBackwardSeeks_EachResetsIndependently()
+        {
+            var tracker = new PartitionCommitTracker();
+            tracker.Track(100);
+
+            // First backward seek to 50.
+            tracker.Track(50); // 50 < 100 → reset, _epochStart=50
+
+            // Second backward seek to 20.
+            tracker.Track(20); // 20 < 50 → reset, _epochStart=20
+
+            // Acks below the final epochStart(20) are discarded.
+            Assert.Null(tracker.Acknowledge(10));
+
+            // Current epoch starts at 20 — ack works.
+            Assert.Equal(21L, tracker.Acknowledge(20));
+        }
+
+        [Fact]
+        public void Track_BackwardSeek_OutOfOrderAcksAfterSeekWorkNormally()
+        {
+            var tracker = new PartitionCommitTracker();
+            tracker.Track(100);
+
+            // Seek backward to 10.
+            tracker.Track(10); // backward: reset, _epochStart=10
+            tracker.Track(11);
+            tracker.Track(12);
+
+            // Ack out of order: 12, 11, then 10.
+            Assert.Null(tracker.Acknowledge(12));   // gap at 10 and 11
+            Assert.Null(tracker.Acknowledge(11));   // gap at 10
+            Assert.Equal(13L, tracker.Acknowledge(10)); // fills gap → bulk advance to 12
+        }
+
+        [Fact]
+        public void Track_BackwardSeek_ClearsPhantomGaps()
+        {
+            // A backward seek must clear any pending phantom ranges, otherwise
+            // a range recorded before the seek could interfere with the new epoch.
+            var tracker = new PartitionCommitTracker();
+            tracker.Track(0);
+            tracker.Track(5); // forward gap with 0 in-flight → phantom range (1,4) enqueued
+
+            // Seek backward to 10 (offset 10 > lastTracked=5 is a forward jump... use 3 instead)
+            // Actually demonstrate with a backward seek that discards the phantom range:
+            tracker.Track(0); // 0 < 5 → backward: resets HWM, acked, AND phantom-gap queue
+
+            // After reset, phantom range (1,4) must be gone.
+            // Ack 0 in the new epoch — should commit at 1 without any phantom interference.
+            Assert.Equal(1L, tracker.Acknowledge(0));
+        }
+
         // ─── Stale ack on old tracker instance (rebalance simulation) ─────────────
 
         [Fact]

--- a/src/Take.Elephant.Tests/Kafka/PartitionCommitTrackerFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/PartitionCommitTrackerFacts.cs
@@ -221,19 +221,20 @@ namespace Take.Elephant.Tests.Kafka
         [Fact]
         public void Track_BackwardSeek_StaleAckAtOverlappingOffset_Discarded()
         {
-            // Key scenario: an in-flight ack delegate holds an offset that falls WITHIN the
-            // new epoch's range (offset >= new epochStart), but was tracked in the old epoch.
-            // The old _epochStart check alone would NOT catch this; only epoch-id validation does.
+            // Key scenario: in-flight ack delegates hold offsets that fall WITHIN the new epoch's
+            // range (offset >= new epochStart), but were tracked in the old epoch. The old
+            // _epochStart check alone would NOT catch these; only epoch-id validation does.
             var tracker = new PartitionCommitTracker();
-            tracker.Track(50);
-            var staleEpoch55 = tracker.Track(55); // epoch 0, offset 55
+            var staleEpoch = tracker.Track(50);  // epoch 0
+            tracker.Track(55);                   // also epoch 0, offset 55 > epochStart will be 40
 
             // Backward seek to 40 → epochStart=40, epoch incremented to 1.
             var newEpoch40 = tracker.Track(40);
 
-            // Stale ack for offset 55 (epoch 0): 55 >= epochStart(40) so the old offset-comparison
-            // guard would have accepted it — the epoch-id check correctly rejects it.
-            Assert.Null(tracker.Acknowledge(55, staleEpoch55));
+            // Stale acks from epoch 0: offsets 50 and 55 are both >= epochStart(40), so the
+            // old offset-comparison guard would have accepted them — the epoch-id check rejects both.
+            Assert.Null(tracker.Acknowledge(50, staleEpoch));
+            Assert.Null(tracker.Acknowledge(55, staleEpoch));
 
             // Legitimate ack in the new epoch commits correctly.
             Assert.Equal(41L, tracker.Acknowledge(40, newEpoch40));

--- a/src/Take.Elephant.Tests/Kafka/PartitionCommitTrackerFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/PartitionCommitTrackerFacts.cs
@@ -1,0 +1,120 @@
+using Take.Elephant.Kafka;
+using Xunit;
+
+namespace Take.Elephant.Tests.Kafka
+{
+    [Trait("Category", nameof(Kafka))]
+    public class PartitionCommitTrackerFacts
+    {
+        // ─── Single offset ────────────────────────────────────────────────────────
+
+        [Fact]
+        public void Acknowledge_SingleOffset_ReturnsNextOffset()
+        {
+            var tracker = new PartitionCommitTracker();
+            tracker.Track(0);
+
+            var result = tracker.Acknowledge(0);
+
+            Assert.Equal(1L, result);
+        }
+
+        // ─── In-order sequential ──────────────────────────────────────────────────
+
+        [Fact]
+        public void Acknowledge_InOrder_AdvancesHWMStepByStep()
+        {
+            var tracker = new PartitionCommitTracker();
+            tracker.Track(0);
+            tracker.Track(1);
+            tracker.Track(2);
+
+            Assert.Equal(1L, tracker.Acknowledge(0));
+            Assert.Equal(2L, tracker.Acknowledge(1));
+            Assert.Equal(3L, tracker.Acknowledge(2));
+        }
+
+        // ─── Out-of-order / gap blocking ──────────────────────────────────────────
+
+        [Fact]
+        public void Acknowledge_OutOfOrder_HoldsUntilGapFilled()
+        {
+            var tracker = new PartitionCommitTracker();
+            tracker.Track(0);
+            tracker.Track(1);
+            tracker.Track(2);
+
+            // Ack 1 and 2 first — gap at 0 blocks advance
+            Assert.Null(tracker.Acknowledge(1));
+            Assert.Null(tracker.Acknowledge(2));
+
+            // Fill gap at 0 — HWM bulk-advances to 2, commit at 3
+            Assert.Equal(3L, tracker.Acknowledge(0));
+        }
+
+        // ─── Partial advance then batch ───────────────────────────────────────────
+
+        [Fact]
+        public void Acknowledge_GapInMiddle_PartialAdvanceThenBatch()
+        {
+            var tracker = new PartitionCommitTracker();
+            tracker.Track(0);
+            tracker.Track(1);
+            tracker.Track(2);
+            tracker.Track(3);
+
+            Assert.Equal(1L, tracker.Acknowledge(0));  // HWM=0, commit 1
+            Assert.Null(tracker.Acknowledge(2));        // gap at 1
+            Assert.Equal(3L, tracker.Acknowledge(1));  // fills gap → HWM=2, commit 3
+            Assert.Equal(4L, tracker.Acknowledge(3));  // HWM=3, commit 4
+        }
+
+        // ─── Defensive bootstrap (Acknowledge without prior Track) ────────────────
+
+        [Fact]
+        public void Acknowledge_WithoutTrack_DefensiveBootstrap_CommitsFromOffset()
+        {
+            var tracker = new PartitionCommitTracker();
+
+            var result = tracker.Acknowledge(5);
+
+            Assert.Equal(6L, result);
+        }
+
+        // ─── Non-zero starting offset ─────────────────────────────────────────────
+
+        [Fact]
+        public void Track_NonZeroStart_HWMRelativeToFirstOffset()
+        {
+            var tracker = new PartitionCommitTracker();
+            tracker.Track(100);
+            tracker.Track(101);
+
+            Assert.Equal(101L, tracker.Acknowledge(100));
+            Assert.Equal(102L, tracker.Acknowledge(101));
+        }
+
+        // ─── Stale ack on old tracker instance (rebalance simulation) ─────────────
+
+        [Fact]
+        public void Acknowledge_OnOldInstance_DoesNotAffectNewInstance()
+        {
+            // Simulates what happens after a rebalance:
+            // KafkaReceiverQueue replaces the tracker with a new instance.
+            var oldTracker = new PartitionCommitTracker();
+            oldTracker.Track(0);
+            oldTracker.Track(1);
+
+            // New assignment starts at offset 50
+            var newTracker = new PartitionCommitTracker();
+            newTracker.Track(50);
+
+            // Old in-flight delegate acks offset 0 on the old instance
+            var commitFromOld = oldTracker.Acknowledge(0);
+            Assert.Equal(1L, commitFromOld); // old tracker advances normally
+
+            // New tracker is completely unaffected
+            Assert.Equal(51L, newTracker.Acknowledge(50));
+        }
+    }
+}

--- a/src/Take.Elephant.Tests/Kafka/PartitionCommitTrackerFacts.cs
+++ b/src/Take.Elephant.Tests/Kafka/PartitionCommitTrackerFacts.cs
@@ -12,9 +12,9 @@ namespace Take.Elephant.Tests.Kafka
         public void Acknowledge_SingleOffset_ReturnsNextOffset()
         {
             var tracker = new PartitionCommitTracker();
-            tracker.Track(0);
+            var epoch = tracker.Track(0);
 
-            var result = tracker.Acknowledge(0);
+            var result = tracker.Acknowledge(0, epoch);
 
             Assert.Equal(1L, result);
         }
@@ -25,13 +25,13 @@ namespace Take.Elephant.Tests.Kafka
         public void Acknowledge_InOrder_AdvancesHWMStepByStep()
         {
             var tracker = new PartitionCommitTracker();
-            tracker.Track(0);
-            tracker.Track(1);
-            tracker.Track(2);
+            var e0 = tracker.Track(0);
+            var e1 = tracker.Track(1);
+            var e2 = tracker.Track(2);
 
-            Assert.Equal(1L, tracker.Acknowledge(0));
-            Assert.Equal(2L, tracker.Acknowledge(1));
-            Assert.Equal(3L, tracker.Acknowledge(2));
+            Assert.Equal(1L, tracker.Acknowledge(0, e0));
+            Assert.Equal(2L, tracker.Acknowledge(1, e1));
+            Assert.Equal(3L, tracker.Acknowledge(2, e2));
         }
 
         // ─── Out-of-order / gap blocking ──────────────────────────────────────────
@@ -40,16 +40,16 @@ namespace Take.Elephant.Tests.Kafka
         public void Acknowledge_OutOfOrder_HoldsUntilGapFilled()
         {
             var tracker = new PartitionCommitTracker();
-            tracker.Track(0);
-            tracker.Track(1);
-            tracker.Track(2);
+            var e0 = tracker.Track(0);
+            var e1 = tracker.Track(1);
+            var e2 = tracker.Track(2);
 
             // Ack 1 and 2 first — gap at 0 blocks advance
-            Assert.Null(tracker.Acknowledge(1));
-            Assert.Null(tracker.Acknowledge(2));
+            Assert.Null(tracker.Acknowledge(1, e1));
+            Assert.Null(tracker.Acknowledge(2, e2));
 
             // Fill gap at 0 — HWM bulk-advances to 2, commit at 3
-            Assert.Equal(3L, tracker.Acknowledge(0));
+            Assert.Equal(3L, tracker.Acknowledge(0, e0));
         }
 
         // ─── Partial advance then batch ───────────────────────────────────────────
@@ -58,15 +58,15 @@ namespace Take.Elephant.Tests.Kafka
         public void Acknowledge_GapInMiddle_PartialAdvanceThenBatch()
         {
             var tracker = new PartitionCommitTracker();
-            tracker.Track(0);
-            tracker.Track(1);
-            tracker.Track(2);
-            tracker.Track(3);
+            var e0 = tracker.Track(0);
+            var e1 = tracker.Track(1);
+            var e2 = tracker.Track(2);
+            var e3 = tracker.Track(3);
 
-            Assert.Equal(1L, tracker.Acknowledge(0));  // HWM=0, commit 1
-            Assert.Null(tracker.Acknowledge(2));        // gap at 1
-            Assert.Equal(3L, tracker.Acknowledge(1));  // fills gap → HWM=2, commit 3
-            Assert.Equal(4L, tracker.Acknowledge(3));  // HWM=3, commit 4
+            Assert.Equal(1L, tracker.Acknowledge(0, e0));  // HWM=0, commit 1
+            Assert.Null(tracker.Acknowledge(2, e2));        // gap at 1
+            Assert.Equal(3L, tracker.Acknowledge(1, e1));  // fills gap → HWM=2, commit 3
+            Assert.Equal(4L, tracker.Acknowledge(3, e3));  // HWM=3, commit 4
         }
 
         // ─── Defensive bootstrap (Acknowledge without prior Track) ────────────────
@@ -76,7 +76,8 @@ namespace Take.Elephant.Tests.Kafka
         {
             var tracker = new PartitionCommitTracker();
 
-            var result = tracker.Acknowledge(5);
+            // Epoch is 0 when no backward seek has occurred.
+            var result = tracker.Acknowledge(5, 0L);
 
             Assert.Equal(6L, result);
         }
@@ -87,11 +88,11 @@ namespace Take.Elephant.Tests.Kafka
         public void Track_NonZeroStart_HWMRelativeToFirstOffset()
         {
             var tracker = new PartitionCommitTracker();
-            tracker.Track(100);
-            tracker.Track(101);
+            var e100 = tracker.Track(100);
+            var e101 = tracker.Track(101);
 
-            Assert.Equal(101L, tracker.Acknowledge(100));
-            Assert.Equal(102L, tracker.Acknowledge(101));
+            Assert.Equal(101L, tracker.Acknowledge(100, e100));
+            Assert.Equal(102L, tracker.Acknowledge(101, e101));
         }
 
         // ─── Seek / intra-assignment offset discontinuity ─────────────────────────
@@ -101,16 +102,16 @@ namespace Take.Elephant.Tests.Kafka
         {
             // Consumption starts at 50.
             var tracker = new PartitionCommitTracker();
-            tracker.Track(50);
+            var e50 = tracker.Track(50);
             tracker.Track(51);
-            tracker.Acknowledge(50);    // HWM = 50, next expected = 51
+            tracker.Acknowledge(50, e50);   // HWM = 50, next expected = 51
 
             // Seek backward to offset 10 (replaying old messages).
-            // 10 < 51 → backward branch → reset HWM, acked set, and phantom-gap queue.
-            tracker.Track(10);
+            // 10 < 51 → backward branch → reset HWM, acked set, phantom-gap queue, and advance epoch.
+            var e10 = tracker.Track(10);
 
             // Ack 10 must commit at 11, not get confused by the previous HWM.
-            Assert.Equal(11L, tracker.Acknowledge(10));
+            Assert.Equal(11L, tracker.Acknowledge(10, e10));
         }
 
         // ─── Forward gaps (compaction / aborted transactions) ─────────────────────
@@ -122,19 +123,19 @@ namespace Take.Elephant.Tests.Kafka
             // offset 3 arrives because offset 2 was compacted.
             // The tracker must NOT commit until both 0 and 1 are acked.
             var tracker = new PartitionCommitTracker();
-            tracker.Track(0);
-            tracker.Track(1);
-            tracker.Track(3); // forward gap: phantom range (2,2) enqueued — O(1), no loop
+            var e0 = tracker.Track(0);
+            var e1 = tracker.Track(1);
+            var e3 = tracker.Track(3); // forward gap: phantom range (2,2) enqueued — O(1), no loop
 
             // Ack 3 first (fast handler) — HWM cannot advance past 0's pending slot.
-            Assert.Null(tracker.Acknowledge(3));
+            Assert.Null(tracker.Acknowledge(3, e3));
 
             // Ack 0 — HWM advances to 0, but stops because 1 is still pending.
-            Assert.Equal(1L, tracker.Acknowledge(0));
+            Assert.Equal(1L, tracker.Acknowledge(0, e0));
 
             // Ack 1 — fills the real gap; the phantom range (2,2) is dequeued in one step;
             // HWM bulk-advances through 1 → phantom 2 → 3 → commit at 4.
-            Assert.Equal(4L, tracker.Acknowledge(1));
+            Assert.Equal(4L, tracker.Acknowledge(1, e1));
         }
 
         [Fact]
@@ -143,18 +144,18 @@ namespace Take.Elephant.Tests.Kafka
             // All prior offsets are committed before the gap arrives.
             // No phantom loop needed — _lastCommitted jumps directly.
             var tracker = new PartitionCommitTracker();
-            tracker.Track(0);
-            tracker.Track(1);
-            tracker.Track(2);
-            Assert.Equal(1L, tracker.Acknowledge(0));
-            Assert.Equal(2L, tracker.Acknowledge(1));
-            Assert.Equal(3L, tracker.Acknowledge(2)); // _lastCommitted==2 == _lastTracked==2, _acked={}
+            var e0 = tracker.Track(0);
+            var e1 = tracker.Track(1);
+            var e2 = tracker.Track(2);
+            Assert.Equal(1L, tracker.Acknowledge(0, e0));
+            Assert.Equal(2L, tracker.Acknowledge(1, e1));
+            Assert.Equal(3L, tracker.Acknowledge(2, e2)); // _lastCommitted==2 == _lastTracked==2, _acked={}
 
             // Gap: offsets 3–99 were compacted; 100 is the next delivered offset.
-            tracker.Track(100); // forward gap, no in-flight → O(1) advance
+            var e100 = tracker.Track(100); // forward gap, no in-flight → O(1) advance
 
             // Ack 100 should commit at 101 immediately (no phantom loop necessary).
-            Assert.Equal(101L, tracker.Acknowledge(100));
+            Assert.Equal(101L, tracker.Acknowledge(100, e100));
         }
 
         [Fact]
@@ -163,18 +164,18 @@ namespace Take.Elephant.Tests.Kafka
             // The phantom range must be removed from the queue as the HWM advances through it.
             // This test verifies that the queue does not retain phantom ranges after the HWM passes.
             var tracker = new PartitionCommitTracker();
-            tracker.Track(0);
-            tracker.Track(5); // forward gap with 0 still in flight → phantom range (1,4) enqueued
+            var e0 = tracker.Track(0);
+            var e5 = tracker.Track(5); // forward gap with 0 still in flight → phantom range (1,4) enqueued
 
             // Ack 5 first — HWM stuck at -1 (waiting for 0).
-            Assert.Null(tracker.Acknowledge(5));
+            Assert.Null(tracker.Acknowledge(5, e5));
 
             // Ack 0 — HWM advances: 0 → phantom range (1,4) dequeued (skip to 4) → 5 → stop. Commit at 6.
-            Assert.Equal(6L, tracker.Acknowledge(0));
+            Assert.Equal(6L, tracker.Acknowledge(0, e0));
 
             // Subsequent track/ack at 6 confirms no leftover state in _acked.
-            tracker.Track(6);
-            Assert.Equal(7L, tracker.Acknowledge(6));
+            var e6 = tracker.Track(6);
+            Assert.Equal(7L, tracker.Acknowledge(6, e6));
         }
 
         [Fact]
@@ -182,75 +183,97 @@ namespace Take.Elephant.Tests.Kafka
         {
             // Two separate compaction gaps in the same assignment.
             var tracker = new PartitionCommitTracker();
-            tracker.Track(0);
-            Assert.Equal(1L, tracker.Acknowledge(0)); // _lastCommitted=0, _lastTracked=0
+            var e0 = tracker.Track(0);
+            Assert.Equal(1L, tracker.Acknowledge(0, e0)); // _lastCommitted=0, _lastTracked=0
 
             // Gap 1: offsets 1-4 compacted, 5 arrives.
             // _acked={}, _lastCommitted(0)==_lastTracked(0) → O(1): _lastCommitted=4
-            tracker.Track(5);
+            var e5 = tracker.Track(5);
 
             // Ack 5: fills _acked, no gap → commit at 6.
-            Assert.Equal(6L, tracker.Acknowledge(5)); // _lastCommitted=5, _lastTracked=5
+            Assert.Equal(6L, tracker.Acknowledge(5, e5)); // _lastCommitted=5, _lastTracked=5
 
             // Gap 2: offsets 6-9 compacted, 10 arrives.
             // _acked={}, _lastCommitted(5)==_lastTracked(5) → O(1): _lastCommitted=9
-            tracker.Track(10);
+            var e10 = tracker.Track(10);
 
-            Assert.Equal(11L, tracker.Acknowledge(10));
+            Assert.Equal(11L, tracker.Acknowledge(10, e10));
         }
 
         [Fact]
-        public void Track_BackwardSeek_StaleAcksBeforeEpochStart_Discarded()
+        public void Track_BackwardSeek_StaleAcksFromOldEpoch_Discarded()
         {
-            // After a backward seek to offset 50, acks for offsets below 50 are discarded.
+            // After a backward seek, acks carrying the old epoch id are rejected.
             var tracker = new PartitionCommitTracker();
-            tracker.Track(100);
+            var staleEpoch = tracker.Track(100);
             tracker.Track(101);
 
-            // Seek backward to 50.
-            tracker.Track(50); // backward: reset, _epochStart=50
+            // Seek backward to 50 — epoch is incremented.
+            var newEpoch = tracker.Track(50); // backward: reset, epoch advances
 
-            // Ack for offset 40 (below epochStart=50) must be discarded.
-            Assert.Null(tracker.Acknowledge(40));
+            // Ack from the old epoch (below new epochStart=50) must be discarded.
+            Assert.Null(tracker.Acknowledge(40, staleEpoch));
 
-            // Ack for the new epoch works normally.
-            Assert.Equal(51L, tracker.Acknowledge(50));
+            // Ack in the new epoch works normally.
+            Assert.Equal(51L, tracker.Acknowledge(50, newEpoch));
+        }
+
+        [Fact]
+        public void Track_BackwardSeek_StaleAckAtOverlappingOffset_Discarded()
+        {
+            // Key scenario: an in-flight ack delegate holds an offset that falls WITHIN the
+            // new epoch's range (offset >= new epochStart), but was tracked in the old epoch.
+            // The old _epochStart check alone would NOT catch this; only epoch-id validation does.
+            var tracker = new PartitionCommitTracker();
+            tracker.Track(50);
+            var staleEpoch55 = tracker.Track(55); // epoch 0, offset 55
+
+            // Backward seek to 40 → epochStart=40, epoch incremented to 1.
+            var newEpoch40 = tracker.Track(40);
+
+            // Stale ack for offset 55 (epoch 0): 55 >= epochStart(40) so the old offset-comparison
+            // guard would have accepted it — the epoch-id check correctly rejects it.
+            Assert.Null(tracker.Acknowledge(55, staleEpoch55));
+
+            // Legitimate ack in the new epoch commits correctly.
+            Assert.Equal(41L, tracker.Acknowledge(40, newEpoch40));
         }
 
         [Fact]
         public void Track_MultipleBackwardSeeks_EachResetsIndependently()
         {
             var tracker = new PartitionCommitTracker();
-            tracker.Track(100);
+            tracker.Track(100);                       // epoch 0
 
             // First backward seek to 50.
-            tracker.Track(50); // 50 < 100 → reset, _epochStart=50
+            tracker.Track(50); // 50 < 100 → reset, epoch becomes 1
 
             // Second backward seek to 20.
-            tracker.Track(20); // 20 < 50 → reset, _epochStart=20
+            tracker.Track(20); // 20 < 50 → reset, epoch becomes 2
 
-            // Acks below the final epochStart(20) are discarded.
-            Assert.Null(tracker.Acknowledge(10));
+            // Acks from superseded epochs are discarded.
+            Assert.Null(tracker.Acknowledge(10, 0L)); // epoch 0 — stale
+            Assert.Null(tracker.Acknowledge(10, 1L)); // epoch 1 — stale
 
-            // Current epoch starts at 20 — ack works.
-            Assert.Equal(21L, tracker.Acknowledge(20));
+            // Current epoch is 2; offset 20 was the last tracked after the final seek.
+            Assert.Equal(21L, tracker.Acknowledge(20, 2L));
         }
 
         [Fact]
         public void Track_BackwardSeek_OutOfOrderAcksAfterSeekWorkNormally()
         {
             var tracker = new PartitionCommitTracker();
-            tracker.Track(100);
+            tracker.Track(100); // epoch 0
 
             // Seek backward to 10.
-            tracker.Track(10); // backward: reset, _epochStart=10
-            tracker.Track(11);
-            tracker.Track(12);
+            var e10 = tracker.Track(10); // backward: epoch = 1
+            var e11 = tracker.Track(11);
+            var e12 = tracker.Track(12);
 
             // Ack out of order: 12, 11, then 10.
-            Assert.Null(tracker.Acknowledge(12));   // gap at 10 and 11
-            Assert.Null(tracker.Acknowledge(11));   // gap at 10
-            Assert.Equal(13L, tracker.Acknowledge(10)); // fills gap → bulk advance to 12
+            Assert.Null(tracker.Acknowledge(12, e12));   // gap at 10 and 11
+            Assert.Null(tracker.Acknowledge(11, e11));   // gap at 10
+            Assert.Equal(13L, tracker.Acknowledge(10, e10)); // fills gap → bulk advance to 12
         }
 
         [Fact]
@@ -262,13 +285,29 @@ namespace Take.Elephant.Tests.Kafka
             tracker.Track(0);
             tracker.Track(5); // forward gap with 0 in-flight → phantom range (1,4) enqueued
 
-            // Seek backward to 10 (offset 10 > lastTracked=5 is a forward jump... use 3 instead)
-            // Actually demonstrate with a backward seek that discards the phantom range:
-            tracker.Track(0); // 0 < 5 → backward: resets HWM, acked, AND phantom-gap queue
+            // Backward seek (0 < 5) discards the phantom range.
+            var e0 = tracker.Track(0); // 0 < 5 → backward: resets HWM, acked, AND phantom-gap queue
 
             // After reset, phantom range (1,4) must be gone.
             // Ack 0 in the new epoch — should commit at 1 without any phantom interference.
-            Assert.Equal(1L, tracker.Acknowledge(0));
+            Assert.Equal(1L, tracker.Acknowledge(0, e0));
+        }
+
+        // ─── Duplicate / already-committed acks ──────────────────────────────────
+
+        [Fact]
+        public void Acknowledge_DuplicateAck_DoesNotGrowAckedSet()
+        {
+            // Acking an already-committed offset must be a no-op (returns null, no memory leak).
+            var tracker = new PartitionCommitTracker();
+            var e0 = tracker.Track(0);
+            var e1 = tracker.Track(1);
+
+            Assert.Equal(1L, tracker.Acknowledge(0, e0)); // commits offset 0
+            Assert.Equal(2L, tracker.Acknowledge(1, e1)); // commits offset 1
+
+            // Duplicate ack of offset 0 — already committed, must be silently discarded.
+            Assert.Null(tracker.Acknowledge(0, e0));
         }
 
         // ─── Stale ack on old tracker instance (rebalance simulation) ─────────────
@@ -279,19 +318,19 @@ namespace Take.Elephant.Tests.Kafka
             // Simulates what happens after a rebalance:
             // KafkaReceiverQueue replaces the tracker with a new instance.
             var oldTracker = new PartitionCommitTracker();
-            oldTracker.Track(0);
+            var oe0 = oldTracker.Track(0);
             oldTracker.Track(1);
 
             // New assignment starts at offset 50
             var newTracker = new PartitionCommitTracker();
-            newTracker.Track(50);
+            var ne50 = newTracker.Track(50);
 
             // Old in-flight delegate acks offset 0 on the old instance
-            var commitFromOld = oldTracker.Acknowledge(0);
+            var commitFromOld = oldTracker.Acknowledge(0, oe0);
             Assert.Equal(1L, commitFromOld); // old tracker advances normally
 
             // New tracker is completely unaffected
-            Assert.Equal(51L, newTracker.Acknowledge(50));
+            Assert.Equal(51L, newTracker.Acknowledge(50, ne50));
         }
     }
 }


### PR DESCRIPTION
## Motivation

In the current Kafka consumer implementation (`KafkaAckMode.Eager`), offsets are
auto-committed by the Confluent client at the moment `consumer.Consume()` is
called — **before** business processing completes. If a pod restarts while a
message is being processed, the offset has already been committed and the message
is silently lost.

This PR introduces opt-in acknowledgement modes (`OnSuccess` and `Manual`) that
commit offsets only after confirmed processing, eliminating the silent-loss
window.

---

## What Changed

### New types (`Take.Elephant.Kafka`)

| File | Description |
|---|---|
| `KafkaAckMode.cs` | Enum: `Eager` (default, legacy), `OnSuccess`, `Manual` |
| `KafkaAckableMessage.cs` | Message envelope carrying payload, headers, topic/partition/offset metadata, and an `AcknowledgeAsync()` delegate. Idempotent (double-ack is a no-op). Reset-on-failure: if the underlying `Commit()` throws, `IsAcknowledged` remains `false` so the caller can retry. |
| `IKafkaAckableReceiverQueue.cs` | Dedicated interface with `DequeueAckableAsync` and `DequeueAckableOrDefaultAsync`. Intentionally **not** derived from `IKafkaReceiverQueue` to prevent LSP violations — code typed against the base interface could receive an ackable instance and fail at runtime when calling the wrong Dequeue family. |
| `PartitionCommitTracker.cs` | Thread-safe per-partition high-water-mark tracker. Commits only when all offsets from the last committed point are contiguous. Handles forward gaps (log compaction, aborted transactions) via O(1) phantom-range tracking, and backward seeks (manual `consumer.Seek()`) via monotonically-increasing epoch tokens. |

### Modified (`KafkaReceiverQueue`)

- Now implements both `IKafkaAckableReceiverQueue<T>` and `IKafkaReceiverQueue<T>`.
- **Binary-compatible explicit overloads** added for every existing constructor signature. Existing callers (`KafkaQueue`, `KafkaPartitionQueue`, and any downstream assemblies compiled against the previous version) require **zero code changes**.
  - `(string bootstrapServers, string topic, string groupId, ISerializer, IDeserializer?)`
  - `(ConsumerConfig, string topic, ISerializer, IDeserializer?)`
  - `(IConsumer, ISerializer, string topic)`
  > Note: new overloads that accept `KafkaAckMode` require `IDeserializer` as a non-optional parameter to avoid CLR signature ambiguity with the binary-compatible overloads above.
- `_closed` field changed from `bool` to `volatile bool` (thread-visibility fix).
- When `ackMode != Eager`: sets `EnableAutoCommit=false` and `EnableAutoOffsetStore=false`; uses a dedicated `_ackableChannel` (capacity 1) and one `PartitionCommitTracker` per assigned partition.
- Rebalance handlers (`SetPartitionsAssignedHandler`, `SetPartitionsRevokedHandler`, `SetPartitionsLostHandler`) installed automatically for non-Eager modes to reset per-partition state on rebalance.
- `DequeueAsync` / `DequeueOrDefaultAsync` / `DequeueWithHeadersAsync` / `DequeueWithHeadersOrDefaultAsync` throw `InvalidOperationException` when called in non-Eager mode (error message guides migration).
- `DequeueAckableAsync` / `DequeueAckableOrDefaultAsync` throw `InvalidOperationException` when called in Eager mode.
- `(IConsumer, ISerializer, string, KafkaAckMode)` public constructor throws `ArgumentException` for non-Eager modes — an injected consumer cannot be guaranteed to have `EnableAutoCommit=false`, so non-Eager requires the `ConsumerConfig` constructor path.
- **Static factory class `KafkaReceiverQueue`** added — returns `KafkaReceiverQueue<T>` (concrete type) in all cases so callers retain access to lifecycle operations (`OpenAsync`, `CloseAsync`, `Dispose`). Note: the concrete type implements both interfaces; assigning a non-Eager instance to `IKafkaReceiverQueue<T>` and calling `Dequeue*` will throw `InvalidOperationException` at runtime — prefer `IKafkaAckableReceiverQueue<T>` for non-Eager instances.

### `PartitionCommitTracker` — epoch-based stale ack rejection

- `Track(offset)` now returns a `long` epoch id. Callers **must** pass it back to `Acknowledge(offset, epochId)`.
- `_currentEpoch` is a monotonically-increasing counter incremented on every backward seek. This invalidates **all** in-flight ack delegates from the old position, including those whose offset falls within the new epoch's range — which the previous `offset < _epochStart` guard alone could not catch.
- `Acknowledge(offset, epochId)` discards the ack when `epochId != _currentEpoch`.
- Defense-in-depth: `offset < _epochStart` is still checked after epoch validation.
- Duplicate/stale acks for already-committed offsets are discarded early (`offset <= _lastCommitted`) to prevent unbounded `_acked` set growth.

### Modified (`KafkaHeadersConverter`)

- `internal static ToReadOnlyDictionary(Headers)` added — exposed as an internal alias for ackable message construction.

### Tests (`Take.Elephant.Tests`)

| File | Facts |
|---|---|
| `KafkaReceiverQueueAckModeFacts.cs` | **23 tests** covering: Eager preserves legacy behavior; Eager throws on ackable methods before consumer starts; OnSuccess/Manual dequeue, commit, idempotency, and no-commit-before-ack; out-of-order acks hold HWM until gap is filled; all legacy `Dequeue*` methods throw in non-Eager mode; ack after `CloseAsync` does not throw (`ObjectDisposedException` swallowed); broker exception propagates when partition is active; broker exception is retryable (cached commit offset reused); partition revocation before ack skips commit silently; concurrent acks on same partition are monotonic; factory returns correct concrete type per mode; public `IConsumer<>` constructor rejects non-Eager mode. |
| `PartitionCommitTrackerFacts.cs` | **18 tests** covering: single offset; in-order sequential; out-of-order gap blocking with bulk advance; partial advance then batch; defensive bootstrap (ack without prior Track); non-zero starting offset; backward seek resets HWM to new base; backward seek discards stale acks from old epoch by epoch-id mismatch; backward seek discards stale acks at overlapping offsets (epoch-id check, not offset comparison); multiple backward seeks; backward seek clears phantom-gap queue; forward gap with in-flight messages (phantom range queued O(1), HWM blocked until predecessors acked); forward gap without in-flight messages (O(1) HWM advance); phantom range dequeued on advance (no memory leak); multiple forward gaps; duplicate ack on already-committed offset is a no-op (no `_acked` growth); stale ack on old tracker instance does not affect new instance. |

---

## Ack Mode Semantics

```
Eager     → offset committed by Confluent auto-commit (before processing) [default, no change]
OnSuccess → offset committed only after AcknowledgeAsync() is called by the pipeline
Manual    → same commit semantics as OnSuccess; the name signals explicit application control
```

### PartitionCommitTracker — contiguous commit rule

```
Track(5), Track(6), Track(7)

Acknowledge(7, e7) → HWM stuck at 4 (5 and 6 not acked) → returns null → no commit
Acknowledge(5, e5) → HWM=5 → 6 still pending → commit at offset 6
Acknowledge(6, e6) → HWM=7 → bulk advance through 6→7 → commit at offset 8
```

### PartitionCommitTracker — backward seek epoch isolation

```
Track(100)              // epoch=0 captured → staleEpoch=0
Track(50)               // backward seek → epoch becomes 1, epochStart=50 → newEpoch=1

Acknowledge(100, 0)     // epochId(0) != _currentEpoch(1) → discarded
Acknowledge(55, 0)      // epochId(0) != _currentEpoch(1) → discarded (offset >= epochStart but still rejected)
Acknowledge(50, 1)      // epochId matches → HWM advances → commit at 51
```

---

## Backward Compatibility

- All existing constructor signatures are preserved as explicit binary-compatible overloads — no code changes required in downstream consumers.
- `KafkaQueue` and `KafkaPartitionQueue` continue to work without modification.
- Default `KafkaAckMode.Eager` preserves all existing auto-commit behavior.
- The `IConsumer<>` constructor family is Eager-only; non-Eager modes require the `ConsumerConfig` constructor.

---

## Risks

| Risk | Mitigation |
|---|---|
| **Duplicate processing** after pod restart | Expected and correct. Consumers using `OnSuccess`/`Manual` **must be idempotent**. |
| **Offset stuck** if `AcknowledgeAsync` is never called | Partition HWM does not advance → Kafka redelivers on reconnect. No silent loss. |
| **Out-of-order acks with parallel consumers** | `PartitionCommitTracker` holds back commits until contiguous. Safe but may delay commit window. |
| **Injected `IConsumer<>` bypass** | Public constructor throws `ArgumentException` for non-Eager modes; non-Eager requires `ConsumerConfig` constructor path to enforce `EnableAutoCommit=false`. |
| **Rebalance during in-flight ack** | Reference-equality check against `_partitionTrackers` detects revoked partitions; commit is skipped silently. TOCTOU race handled by narrowed `catch (KafkaException) when (...)`. |
| **Non-Eager instance typed as `IKafkaReceiverQueue<T>`** | Calling `Dequeue*` throws `InvalidOperationException` at runtime. Prefer the concrete type or `IKafkaAckableReceiverQueue<T>` for non-Eager instances. |

---

## Testing

```sh
dotnet test src/Take.Elephant.Tests/Take.Elephant.Tests.csproj --filter "Category=Kafka"
```
