### PR TITLE
fix: resolve Newtonsoft.Json security vulnerabilities

### DIFF
--- a/src/Take.Elephant/Take.Elephant.csproj
+++ b/src/Take.Elephant/Take.Elephant.csproj
@@ -21,6 +21,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="SmartFormat.Net" Version="2.3.0" />
     <PackageReference Include="System.Linq.Async" Version="4.0.0" />
     <PackageReference Include="System.Reflection" Version="4.3.0" />


### PR DESCRIPTION
# fix(deps): pin Newtonsoft.Json 13.0.3 to override SmartFormat transitive dependency

## Motivation

Checkmarx identified vulnerability findings related to `Newtonsoft.Json 11.0.2`.
In this repository, that version was being resolved transitively through `SmartFormat.Net 2.3.0`:

```
Take.Elephant.csproj
  └── SmartFormat.Net 2.3.0
        └── Newtonsoft.Json 11.0.2
```

The goal of this change is to force the project to resolve `Newtonsoft.Json` in a secure version without changing SmartFormat behavior.

---

## What was changed

Only one change was made:

### Take.Elephant/Take.Elephant.csproj

```diff
+ <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
```

No other files were changed as part of this PR scope.

---

## Expected result

- `Take.Elephant` resolves `Newtonsoft.Json` as `13.0.3` instead of `11.0.2`.
- The vulnerability finding tied to `11.0.2` is mitigated in this project.
- Runtime behavior remains unchanged because formatting code and SmartFormat integration were not modified.
